### PR TITLE
Supabase-backed SaaS API + endpoint contracts + full E2E coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,26 @@ GOOGLE_API_KEY=your-google-api-key
 # Server configuration
 PORT=5050
 DEBUG=false
+
+# Supabase (optional)
+# If SUPABASE_JWT_SECRET is set, the backend can accept Supabase access tokens via:
+#   Authorization: Bearer <access_token>
+SUPABASE_URL=https://your-project-ref.supabase.co
+SUPABASE_PUBLISHABLE_KEY=your-supabase-publishable-key
+SUPABASE_JWT_SECRET=your-supabase-jwt-secret
+# Optional token claim checks
+# SUPABASE_JWT_AUD=authenticated
+# SUPABASE_JWT_ISS=https://your-project-ref.supabase.co/auth/v1
+
+# Database (optional)
+# To store sessions/scans/reports in Supabase Postgres, set one of:
+#   VPT_APP_DB_URL=postgresql://...
+#   SUPABASE_DATABASE_URL=postgresql://...
+#
+# To store billing/entitlements in Supabase Postgres, set:
+#   VPT_BILLING_DB_URL=postgresql://...
+# Otherwise the app falls back to SQLite at VPT_BILLING_DB_PATH.
+# If VPT_BILLING_DB_URL is not set, billing will also use VPT_APP_DB_URL/SUPABASE_DATABASE_URL when available.
+# VPT_APP_DB_URL=postgresql://postgres:password@db.your-project-ref.supabase.co:5432/postgres
+# VPT_BILLING_DB_URL=postgresql://postgres:password@db.your-project-ref.supabase.co:5432/postgres
+# VPT_BILLING_DB_PATH=data/vpt.db

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -1,0 +1,179 @@
+# HTTP Endpoints
+
+This repository exposes **two** Flask applications:
+
+- `web_api.create_app()` (production app factory used by `run_web.py`, `wsgi.py`, Vercel)
+- `web_ui.app` (legacy monolith used by `python web_ui.py`)
+
+The route inventories below can be regenerated with:
+
+```bash
+python3 scripts/list_routes.py --app both --format markdown
+python3 scripts/update_route_snapshots.py
+```
+
+## Route Inventory (Auto-Generated)
+
+## `web_api` routes (29)
+
+| Methods | Path | Endpoint |
+|---|---|---|
+| `GET` | `/` | `static.index` |
+| `POST` | `/api/activity` | `activity.get_activities` |
+| `POST` | `/api/billing/checkout` | `billing.create_checkout` |
+| `POST` | `/api/billing/webhook` | `billing.billing_webhook` |
+| `GET` | `/api/entitlements` | `billing.get_entitlements` |
+| `GET` | `/api/logs` | `status.get_logs` |
+| `GET` | `/api/report/<report_id>` | `report.get_report` |
+| `GET` | `/api/reports` | `report.get_reports` |
+| `POST` | `/api/scan/cancel` | `scan.cancel_scan` |
+| `POST` | `/api/scan/list` | `scan.list_scans` |
+| `POST` | `/api/scan/start` | `scan.start_scan` |
+| `POST` | `/api/scan/status` | `scan.get_scan_status` |
+| `POST` | `/api/session/check` | `session.check_session` |
+| `POST` | `/api/session/init` | `session.init_session` |
+| `POST` | `/api/session/reset` | `session.reset_session` |
+| `GET, POST` | `/api/session/state` | `session.api_state` |
+| `GET, POST` | `/api/state` | `api_state` |
+| `POST` | `/api/v1/scans` | `v1_scans.create_scan` |
+| `GET` | `/api/v1/scans/<scan_id>` | `v1_scans.get_scan` |
+| `GET` | `/api/v1/scans/<scan_id>/report` | `v1_scans.get_scan_report` |
+| `GET` | `/billing/checkout` | `browser_checkout` |
+| `GET` | `/favicon.ico` | `static.favicon` |
+| `GET` | `/mock-checkout/<checkout_session_id>` | `mock_checkout` |
+| `GET` | `/report` | `get_report_compat` |
+| `GET` | `/reports/<path:filename>` | `download_report` |
+| `POST` | `/reset` | `reset_session` |
+| `POST` | `/scan` | `start_scan_compat` |
+| `GET` | `/static/<path:filename>` | `static.serve_static` |
+| `GET` | `/status` | `status.status_check` |
+
+## `web_ui` routes (24)
+
+| Methods | Path | Endpoint |
+|---|---|---|
+| `GET` | `/` | `index` |
+| `POST` | `/api/activity` | `get_activities` |
+| `POST` | `/api/billing/checkout` | `billing_checkout` |
+| `POST` | `/api/billing/webhook` | `billing_webhook` |
+| `GET` | `/api/entitlements` | `get_entitlements` |
+| `GET` | `/api/logs` | `get_logs` |
+| `GET` | `/api/report/<report_id>` | `get_report` |
+| `GET` | `/api/reports` | `get_reports` |
+| `POST` | `/api/scan/cancel` | `cancel_scan` |
+| `POST` | `/api/scan/list` | `list_scans` |
+| `POST` | `/api/scan/start` | `start_scan` |
+| `POST` | `/api/scan/status` | `get_scan_status` |
+| `POST` | `/api/session/check` | `check_session` |
+| `POST` | `/api/session/init` | `init_session` |
+| `GET, POST` | `/api/state` | `api_state` |
+| `GET` | `/billing/checkout` | `browser_checkout` |
+| `GET` | `/favicon.ico` | `favicon` |
+| `GET` | `/mock-checkout/<checkout_session_id>` | `mock_checkout` |
+| `GET` | `/report` | `get_report_compat` |
+| `GET` | `/reports/<path:filename>` | `download_report` |
+| `POST` | `/reset` | `reset_session` |
+| `POST` | `/scan` | `start_scan_compat` |
+| `GET` | `/static/<path:filename>` | `serve_static` |
+| `GET` | `/status` | `status_check` |
+
+## Behavioral Notes
+
+### Session vs Account Identity
+- `session_id` is used to track scan progress and activity logs (stored by `SessionManager`).
+- Hosted-mode billing uses a separate cookie-backed `account_id`:
+  - `web_api` uses `g.account_id` (cookie `vpt_account_id`)
+  - `web_ui` uses `request._vpt_account_id` (cookie `vpt_account_id`)
+- Supabase auth integration (optional):
+  - If `SUPABASE_JWT_SECRET` is set and requests include `Authorization: Bearer <access_token>`,
+    then `account_id` is derived from the JWT `sub` claim (no account cookie is set).
+
+### Hosted Mode
+Hosted mode is enabled with `VPT_HOSTED_MODE=1`.
+
+In hosted mode, starting scans via:
+- `POST /api/scan/start`
+- `POST /scan` (compat)
+
+enforces:
+- `authorization_confirmed` truthy
+- Target policy (blocks localhost/private IPs via `utils.entitlements.is_valid_target_for_hosted`)
+- Rate limiting (`utils.entitlements.check_scan_rate_limits`)
+- Paywall/entitlements (`BillingStore.try_consume_entitlement_for_scan`)
+
+### Authenticated v1 SaaS API
+- `POST /api/v1/scans`
+- `GET /api/v1/scans/<scan_id>`
+- `GET /api/v1/scans/<scan_id>/report`
+
+These endpoints require Supabase Bearer auth and do **not** fall back to cookie identity:
+- Requests must include `Authorization: Bearer <access_token>`.
+- Access is scoped by org membership (scan ownership enforced via `users/orgs/memberships/saas_scans`).
+
+### Report Availability
+- The UI should use `/status?session_id=...` and check `report_available` before calling `/report?session_id=...`.
+- `GET /api/reports` and `GET /api/report/<report_id>` access reports by report directory ID.
+- Optional Supabase Postgres persistence:
+  - If `VPT_APP_DB_URL` or `SUPABASE_DATABASE_URL` is set to a Postgres URL, scan state, activity logs, and reports are persisted in Postgres.
+  - `/reports/<report_id>/report.json` and `/reports/<report_id>/report.md` will serve from Postgres if the local file is missing.
+
+## Example Requests (Local)
+
+Assume `BASE_URL=http://127.0.0.1:5050`.
+
+### Init Session
+```bash
+curl -sS -X POST "$BASE_URL/api/session/init" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"client_id":"docs"}'
+```
+
+### Start Scan (Hosted Mode)
+```bash
+curl -sS -X POST "$BASE_URL/api/scan/start" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"session_id":"<session_id>","url":"https://example.com","scan_mode":"quick","authorization_confirmed":true}'
+```
+
+### Poll Status
+```bash
+curl -sS "$BASE_URL/status?session_id=<session_id>"
+```
+
+### Fetch Legacy Report
+```bash
+curl -sS "$BASE_URL/report?session_id=<session_id>"
+```
+
+### List Reports and Fetch by ID
+```bash
+curl -sS "$BASE_URL/api/reports"
+curl -sS "$BASE_URL/api/report/<report_id>"
+```
+
+### Billing Checkout (Mock Checkout Available in `VPT_E2E_MODE=1`)
+```bash
+curl -sS -X POST "$BASE_URL/api/billing/checkout" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"scan_mode":"deep"}'
+```
+
+### Create v1 Scan (Auth Required)
+```bash
+curl -sS -X POST "$BASE_URL/api/v1/scans" \\
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \\
+  -H 'Content-Type: application/json' \\
+  -d '{"url":"https://example.com","scan_mode":"quick","authorization_confirmed":true}'
+```
+
+### Poll v1 Scan Status (Auth Required)
+```bash
+curl -sS "$BASE_URL/api/v1/scans/<scan_id>" \\
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
+```
+
+### Fetch v1 Report (Auth Required)
+```bash
+curl -sS "$BASE_URL/api/v1/scans/<scan_id>/report" \\
+  -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
+```

--- a/docs/saas_readiness.md
+++ b/docs/saas_readiness.md
@@ -1,0 +1,171 @@
+# SaaS Readiness (Supabase Auth + DB)
+
+This repo is close to “demo SaaS”, but not yet safe/reliable to charge money without tightening identity, persistence, and worker isolation.
+
+This document assumes you want:
+- Supabase for auth + Postgres database
+- Vercel for web UI
+- A separate containerized worker runtime for scanning (Playwright-heavy)
+
+## What You Already Have (Good SaaS Hooks)
+- Hosted-mode toggle: `VPT_HOSTED_MODE=1`.
+- A paywall/entitlements model with:
+  - `/api/entitlements`
+  - `/api/billing/checkout`
+  - `/api/billing/webhook`
+- Abuse controls in hosted mode:
+  - Explicit authorization confirmation (`authorization_confirmed`)
+  - Localhost/private IP blocking (`utils.entitlements.is_valid_target_for_hosted`)
+  - Rate limiting via usage events (`utils.entitlements.check_scan_rate_limits`)
+- Deterministic end-to-end mode (`VPT_E2E_MODE=1`) for stable CI.
+
+## Critical Gaps Before Charging Money
+- Identity is currently cookie-based (`vpt_account_id`) by default, so users are not “real”.
+  - Cookies are not a durable, tamper-resistant user identity boundary for SaaS.
+- Persistence is still local:
+  - sessions/scan state is in-memory + `sessions.json`
+  - reports are on local disk (`reports/` or `/tmp`)
+  - billing/entitlements are SQLite by default (`data/vpt.db` or `/tmp/vpt.db`)
+- Multi-instance safety:
+  - With multiple web instances, you can get split-brain scan state and inconsistent rate limits.
+- Scanning runtime fit:
+  - Playwright + long-running scans are not a good fit for pure serverless request/response platforms.
+- Security/compliance gaps:
+  - SSRF hardening needs DNS rebinding + redirect-chain re-validation (policy must run in both API and worker).
+  - No retention/deletion policies for scan artifacts (reports can contain sensitive data).
+
+## Changes Implemented In This Repo (Supabase-Ready)
+
+### 1) Supabase Auth (JWT) Support
+If `SUPABASE_JWT_SECRET` is set, the backend accepts Supabase access tokens:
+- Header: `Authorization: Bearer <access_token>`
+- Identity mapping: `account_id = JWT.sub`
+
+This is implemented in:
+- `utils/supabase_auth.py`
+- `web_api/__init__.py` (sets `g.account_id` from Supabase JWT when present)
+- `web_ui.py` (legacy app, same behavior)
+
+Notes:
+- Cookie identity still works as a fallback for OSS/local usage.
+- You can later enforce auth in hosted mode by returning `401` when the token is missing/invalid (policy choice).
+
+### 2) Supabase Postgres For Billing/Entitlements
+Billing/entitlements can now be backed by Supabase Postgres instead of SQLite.
+
+Implemented in:
+- `utils/billing_store_postgres.py` (`PostgresBillingStore`, same method contract as SQLite store)
+- `web_api/__init__.py` and `web_ui.py` select Postgres when a Postgres URL is provided
+
+Enable by setting one of:
+- `VPT_BILLING_DB_URL=postgresql://...`
+- `VPT_APP_DB_URL=postgresql://...` (fallback when `VPT_BILLING_DB_URL` is unset)
+- `SUPABASE_DATABASE_URL=postgresql://...`
+
+If none are set, the app falls back to SQLite `VPT_BILLING_DB_PATH`.
+
+### 3) Supabase Postgres For Sessions/Scans/Reports (Reliability)
+Scan state and reports no longer have to live in `sessions.json` and local `reports/` directories.
+
+Implemented in:
+- `utils/session_manager_postgres.py` (`PostgresSessionManager`)
+- `utils/activity_tracker_postgres.py` (`PostgresActivityTracker`)
+- `utils/report_manager_postgres.py` (`PostgresReportManager`)
+- Wired into `web_api/__init__.py` and `web_ui.py` when a Postgres URL is configured
+
+Enable by setting one of:
+- `VPT_APP_DB_URL=postgresql://...`
+- `SUPABASE_DATABASE_URL=postgresql://...`
+
+Behavior:
+- The scanner still uses local disk as a *staging* directory for subprocess output, but the finalized report is ingested into Postgres for durability (`ScanController` calls `report_manager.ingest_report(...)` when supported).
+- The `/reports/<report_id>/report.json` and `/reports/<report_id>/report.md` routes fall back to serving these artifacts from Postgres when the local file is not present.
+
+### 4) Authenticated v1 Scan API (User/Org Ownership)
+Implemented endpoints:
+- `POST /api/v1/scans` (auth required)
+- `GET /api/v1/scans/<id>` (auth required)
+- `GET /api/v1/scans/<id>/report` (auth required)
+
+Behavior:
+- Requires a valid Supabase Bearer token (`g.supabase_user` must be present).
+- Auto-provisions a personal org on first authenticated request (`users/orgs/memberships`).
+- Persists scan ownership mapping in `saas_scans` and enforces org-based access checks.
+- Reuses the existing scan engine/session state under the hood while establishing SaaS authorization boundaries.
+
+## Recommended Supabase-Backed Architecture
+
+### Web (Vercel)
+- Hosts the UI (static + server-rendered pages if desired).
+- Uses Supabase JS client for:
+  - email/password
+  - magic link
+  - OAuth (Google/GitHub)
+- Calls backend API with `Authorization: Bearer <access_token>`.
+- Recommended env vars on web tier:
+  - `SUPABASE_URL`
+  - `SUPABASE_PUBLISHABLE_KEY`
+
+### API (Flask Web API)
+Keep the current Flask API for now, but treat it as the “control plane”:
+- Validate Supabase JWT for authenticated endpoints
+- Create scan jobs (do not execute scans inline)
+- Report scan status
+- Serve reports or signed URLs
+- Handle billing webhooks (Stripe)
+
+### Worker (Containerized)
+Run scans in a separate worker pool:
+- Pull jobs from a queue
+- Execute Playwright + scan engine
+- Write progress/events to Postgres
+- Upload artifacts to object storage
+
+This is required for reliability and to avoid request timeouts on Vercel/serverless.
+
+### Storage
+- Database: Supabase Postgres
+- Queue/rate limiting: Redis (or Supabase queue equivalent, but Redis is simplest)
+- Artifacts: Supabase Storage (or S3-compatible object store)
+
+## Decision-Complete Data Model (Supabase)
+Supabase provides `auth.users`. You should add your own tables for SaaS behavior.
+
+Suggested tables:
+- `profiles`: `user_id (pk -> auth.users.id)`, `email`, `created_at`
+- `orgs`: `id`, `name`, `created_at`
+- `memberships`: `user_id`, `org_id`, `role`
+- `entitlements`: `org_id (pk)`, `free_scans_remaining`, `credits`, `pro_until`, `updated_at`
+- `scans`: `id`, `org_id`, `created_by_user_id`, `target_url`, `mode`, `status`, `progress`, `created_at`, `started_at`, `finished_at`
+- `scan_events`: `id`, `scan_id`, `ts`, `type`, `payload`
+- `artifacts`: `id`, `scan_id`, `kind`, `storage_key`, `content_type`, `size_bytes`
+- `billing_customers`: `org_id (pk)`, `stripe_customer_id`
+- `checkout_sessions`: `id`, `org_id`, `stripe_session_id`, `mode`, `status`, `amount`, `currency`, `created_at`
+- `usage_events`: `id`, `org_id`, `ip`, `event_type`, `ts`
+
+RLS policy recommendation:
+- Default-deny.
+- Allow members to `SELECT` scans/events for their org.
+- Writes come from the worker and billing webhook using the Supabase service role key (server-side only).
+
+## Public API Shape (SaaS API)
+Keep the existing endpoints for backwards compatibility, but add stable v1 endpoints that are explicitly auth-bound:
+- `POST /api/v1/scans` create scan (Supabase auth required)
+- `GET /api/v1/scans/<id>` status/progress/logs (Supabase auth required)
+- `GET /api/v1/scans/<id>/report` report JSON/markdown or signed URL (Supabase auth required)
+- `POST /api/v1/billing/checkout` checkout (Supabase auth required)
+- `POST /api/v1/billing/webhook` Stripe webhook (signature + idempotency required)
+
+Compatibility layer:
+- Keep `/scan`, `/status`, `/report` for the existing UI, but treat `session_id` as UI convenience only.
+
+## Security/Abuse Controls (Must-Haves)
+- Re-check target policy inside worker:
+  - resolve DNS at execution time (block private)
+  - re-validate every redirect hop
+  - cap redirects
+- Lock down worker networking:
+  - block cloud metadata IPs
+  - restrict outbound ports to `80/443` where possible
+- Move rate limiting counters to Redis for correctness across instances.
+- Add artifact retention + deletion (per org, per scan) and audit logging.

--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ load_dotenv()
 
 
 def parse_arguments():
-    available_providers = ["openai", "anthropic", "ollama"]
+    available_providers = ["openai", "anthropic", "ollama", "mock"]
     if importlib.util.find_spec("google.generativeai") is not None:
         available_providers.append("gemini")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,4 +20,5 @@ markers =
     e2e_frontend_smoke: frontend smoke end-to-end coverage for PR gates
     e2e_frontend_full: full frontend end-to-end coverage for nightly runs
     e2e_vercel_preview: end-to-end smoke checks against deployed Vercel preview URL
+    e2e_live_scan: opt-in live scan end-to-end tests (set VPT_LIVE_E2E=1)
     compat_legacy: legacy web_ui compatibility suite

--- a/requirements-vercel.txt
+++ b/requirements-vercel.txt
@@ -13,3 +13,5 @@ gunicorn>=21.2.0
 python-dotenv>=1.0.0
 # Explicitly specify Flask-CORS rather than using 'flask_cors' format
 Flask-CORS>=4.0.0
+PyJWT>=2.8.0
+psycopg[binary]>=3.1.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ uvicorn>=0.24.0
 flask>=2.2.0
 markdown>=3.4.0
 flask_cors>=4.0.0
+PyJWT>=2.8.0
+psycopg[binary]>=3.1.18
 
 # Testing requirements
 pytest>=7.4.0

--- a/scripts/list_routes.py
+++ b/scripts/list_routes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import logging
+
+# Keep output stable/clean; Flask app imports may configure verbose loggers.
+logging.disable(logging.CRITICAL)
+
+
+@dataclass(frozen=True)
+class RouteRow:
+    rule: str
+    methods: List[str]
+    endpoint: str
+
+
+def _iter_routes(app) -> Iterable[RouteRow]:
+    for rule in app.url_map.iter_rules():
+        # Ignore Flask's built-in static endpoint; we explicitly serve static via our own routes.
+        if rule.endpoint == "static":
+            continue
+        methods = sorted([m for m in rule.methods if m not in {"HEAD", "OPTIONS"}])
+        yield RouteRow(rule=rule.rule, methods=methods, endpoint=rule.endpoint)
+
+
+def _sorted_routes(routes: Iterable[RouteRow]) -> List[RouteRow]:
+    return sorted(
+        list(routes),
+        key=lambda r: (r.rule, ",".join(r.methods), r.endpoint),
+    )
+
+
+def _load_app(app_name: str):
+    # Ensure repo root is on sys.path even when invoked as `python scripts/...`.
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    if app_name == "web_api":
+        from web_api import create_app
+
+        return create_app()
+    if app_name == "web_ui":
+        import web_ui
+
+        return web_ui.app
+    raise ValueError(f"Unknown app: {app_name}")
+
+
+def _routes_payload(app_name: str) -> Dict[str, Any]:
+    app = _load_app(app_name)
+    rows = _sorted_routes(_iter_routes(app))
+    return {
+        "app": app_name,
+        "count": len(rows),
+        "routes": [
+            {
+                "methods": r.methods,
+                "rule": r.rule,
+                "endpoint": r.endpoint,
+            }
+            for r in rows
+        ],
+    }
+
+
+def _print_text(payload: Dict[str, Any]) -> None:
+    print(f"{payload['app']} routes: {payload['count']}")
+    for r in payload["routes"]:
+        methods = ",".join(r["methods"])
+        print(f"{methods:<10} {r['rule']:<35} -> {r['endpoint']}")
+
+
+def _print_markdown(payload: Dict[str, Any]) -> None:
+    print(f"## `{payload['app']}` routes ({payload['count']})\n")
+    print("| Methods | Path | Endpoint |")
+    print("|---|---|---|")
+    for r in payload["routes"]:
+        methods = ", ".join(r["methods"])
+        print(f"| `{methods}` | `{r['rule']}` | `{r['endpoint']}` |")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="List Flask routes for web_api/web_ui.")
+    parser.add_argument(
+        "--app",
+        choices=("web_api", "web_ui", "both"),
+        default="both",
+        help="Which app to inspect (default: both).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json", "markdown"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    args = parser.parse_args(argv)
+
+    apps = ["web_api", "web_ui"] if args.app == "both" else [args.app]
+    payloads = [_routes_payload(a) for a in apps]
+
+    if args.format == "json":
+        print(json.dumps(payloads if len(payloads) > 1 else payloads[0], indent=2))
+        return 0
+
+    for idx, payload in enumerate(payloads):
+        if args.format == "markdown":
+            _print_markdown(payload)
+            if idx != len(payloads) - 1:
+                print()
+            continue
+
+        # text
+        _print_text(payload)
+        if idx != len(payloads) - 1:
+            print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_route_snapshots.py
+++ b/scripts/update_route_snapshots.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import logging
+
+# Keep output stable/clean; Flask app imports may configure verbose loggers.
+logging.disable(logging.CRITICAL)
+
+
+def _routes_for_app(app_name: str) -> List[Dict[str, Any]]:
+    # Ensure repo root is on sys.path even when invoked as `python scripts/...`.
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    if app_name == "web_api":
+        from web_api import create_app
+
+        app = create_app()
+    elif app_name == "web_ui":
+        import web_ui
+
+        app = web_ui.app
+    else:
+        raise ValueError(f"Unknown app: {app_name}")
+
+    routes: List[Dict[str, Any]] = []
+    for rule in app.url_map.iter_rules():
+        if rule.endpoint == "static":
+            continue
+        methods = sorted([m for m in rule.methods if m not in {"HEAD", "OPTIONS"}])
+        routes.append({"rule": rule.rule, "methods": methods})
+
+    routes.sort(key=lambda r: (r["rule"], ",".join(r["methods"])))
+    return routes
+
+
+def _write_snapshot(path: Path, routes: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(routes, indent=2, sort_keys=True) + "\n")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Regenerate route snapshot JSON files under tests/contract/."
+    )
+    parser.add_argument(
+        "--app",
+        choices=("web_api", "web_ui", "both"),
+        default="both",
+        help="Which app snapshots to regenerate (default: both).",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parent.parent
+    contract_dir = repo_root / "tests" / "contract"
+
+    if args.app in ("web_api", "both"):
+        _write_snapshot(
+            contract_dir / "routes_web_api.snapshot.json",
+            _routes_for_app("web_api"),
+        )
+
+    if args.app in ("web_ui", "both"):
+        _write_snapshot(
+            contract_dir / "routes_web_ui.snapshot.json",
+            _routes_for_app("web_ui"),
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/index.html
+++ b/templates/index.html
@@ -625,7 +625,7 @@
             }
             
             // Check for existing scan on page load and restore state
-            function restoreScanStateIfExists() {
+            function restoreScanStateIfExists(retryAttempt = 0) {
                 const savedState = loadScanState();
                 
                 // Always check the server for the session's current state
@@ -637,6 +637,22 @@
                     
                     // If there's no active scan on the server, reset local state and don't display anything
                     if (!serverState.is_running && !serverState.url) {
+                        const hadRecentLocalState = !!(
+                            savedState &&
+                            savedState.sessionId === sessionId &&
+                            (
+                                savedState.isRunning ||
+                                savedState.isComplete ||
+                                (typeof savedState.progress === 'number' && savedState.progress > 0)
+                            )
+                        );
+
+                        if (hadRecentLocalState && retryAttempt < 1) {
+                            console.log('No active scan found on first restore check; retrying once before clearing local state');
+                            setTimeout(() => restoreScanStateIfExists(retryAttempt + 1), 1500);
+                            return;
+                        }
+
                         console.log('No active scan on server, clearing local state');
                         clearScanState();
                         
@@ -770,8 +786,8 @@
                             // Show error state
                             showError(serverState.error || savedState.error);
                         }
-                    } else if (serverState.is_running || serverState.url) {
-                        // No local state but server has an active scan
+                    } else if (serverState.is_running || serverState.url || serverState.report_available) {
+                        // No local state but server has active or recently completed scan data.
                         console.log('Using server state, no local state found');
                         
                         // Save server state to local
@@ -819,6 +835,32 @@
                             // Start polling for updates
                             checkStatus();
                             statusCheckInterval = setInterval(checkStatus, 2000);
+                        } else if (!serverState.error) {
+                            const completedProgress = serverState.progress !== undefined ? serverState.progress : 100;
+                            statusUrlEl.textContent = serverState.url || '-';
+                            currentTaskEl.textContent = serverState.current_task || 'completed';
+                            progressBar.style.width = completedProgress + '%';
+                            progressBar.textContent = completedProgress + '%';
+                            progressBar.classList.remove('progress-bar-striped', 'progress-bar-animated');
+                            progressBar.classList.add('bg-success');
+                            scanStatusPanel.classList.remove('d-none');
+                            startScanBtn.disabled = false;
+                            startScanBtn.innerHTML = '<i class="bi bi-robot"></i> Deploy Agent Swarm';
+                            scanInProgress = false;
+                            document.getElementById('statusPanelTitle').innerHTML =
+                                '<i class="bi bi-check-circle-fill text-success"></i> Scan Complete - Agent Activity Log';
+
+                            if (serverState.report_available) {
+                                loadReport();
+                            } else {
+                                reportContainer.classList.remove('d-none');
+                                reportContentEl.innerHTML = `
+                                    <div class="alert alert-info">
+                                        <h4><i class="bi bi-hourglass-split"></i> Generating Report...</h4>
+                                        <p>The scan has completed and we're generating your report. This should only take a few moments.</p>
+                                    </div>
+                                `;
+                            }
                         }
                     }
                 })

--- a/tests/contract/routes_web_api.snapshot.json
+++ b/tests/contract/routes_web_api.snapshot.json
@@ -1,0 +1,178 @@
+[
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/activity"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/billing/checkout"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/billing/webhook"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/entitlements"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/logs"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/report/<report_id>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/reports"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/cancel"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/list"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/start"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/status"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/session/check"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/session/init"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/session/reset"
+  },
+  {
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/api/session/state"
+  },
+  {
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/api/state"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/v1/scans"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/v1/scans/<scan_id>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/v1/scans/<scan_id>/report"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/billing/checkout"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/favicon.ico"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/mock-checkout/<checkout_session_id>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/report"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/<path:filename>"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/reset"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/scan"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/static/<path:filename>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/status"
+  }
+]

--- a/tests/contract/routes_web_ui.snapshot.json
+++ b/tests/contract/routes_web_ui.snapshot.json
@@ -1,0 +1,147 @@
+[
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/activity"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/billing/checkout"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/billing/webhook"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/entitlements"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/logs"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/report/<report_id>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/api/reports"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/cancel"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/list"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/start"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/scan/status"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/session/check"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/api/session/init"
+  },
+  {
+    "methods": [
+      "GET",
+      "POST"
+    ],
+    "rule": "/api/state"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/billing/checkout"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/favicon.ico"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/mock-checkout/<checkout_session_id>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/report"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/reports/<path:filename>"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/reset"
+  },
+  {
+    "methods": [
+      "POST"
+    ],
+    "rule": "/scan"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/static/<path:filename>"
+  },
+  {
+    "methods": [
+      "GET"
+    ],
+    "rule": "/status"
+  }
+]

--- a/tests/contract/test_routes_snapshot_web_api.py
+++ b/tests/contract/test_routes_snapshot_web_api.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _extract_routes() -> List[Dict[str, Any]]:
+    from web_api import create_app
+
+    app = create_app()
+    routes: List[Dict[str, Any]] = []
+    for rule in app.url_map.iter_rules():
+        # Ignore Flask built-in static endpoint; we explicitly serve static via our own routes.
+        if rule.endpoint == "static":
+            continue
+        methods = sorted([m for m in rule.methods if m not in {"HEAD", "OPTIONS"}])
+        routes.append({"rule": rule.rule, "methods": methods})
+
+    routes.sort(key=lambda r: (r["rule"], ",".join(r["methods"])))
+    return routes
+
+
+def test_web_api_routes_match_snapshot():
+    snapshot_path = Path(__file__).resolve().parent / "routes_web_api.snapshot.json"
+    snapshot = json.loads(snapshot_path.read_text())
+    assert snapshot == _extract_routes()
+

--- a/tests/contract/test_routes_snapshot_web_ui.py
+++ b/tests/contract/test_routes_snapshot_web_ui.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def _extract_routes() -> List[Dict[str, Any]]:
+    import web_ui
+
+    app = web_ui.app
+    routes: List[Dict[str, Any]] = []
+    for rule in app.url_map.iter_rules():
+        # Ignore Flask built-in static endpoint; we explicitly serve static via our own routes.
+        if rule.endpoint == "static":
+            continue
+        methods = sorted([m for m in rule.methods if m not in {"HEAD", "OPTIONS"}])
+        routes.append({"rule": rule.rule, "methods": methods})
+
+    routes.sort(key=lambda r: (r["rule"], ",".join(r["methods"])))
+    return routes
+
+
+def test_web_ui_routes_match_snapshot():
+    snapshot_path = Path(__file__).resolve().parent / "routes_web_ui.snapshot.json"
+    snapshot = json.loads(snapshot_path.read_text())
+    assert snapshot == _extract_routes()
+

--- a/tests/e2e/api/test_report_routes_e2e.py
+++ b/tests/e2e/api/test_report_routes_e2e.py
@@ -73,3 +73,35 @@ def test_reports_file_serving_path(web_api_server, http_client, initialized_sess
         f"{web_api_server}/reports/{report_dir}/report.json", timeout=10
     )
     assert file_resp.status_code == 200
+
+
+@pytest.mark.e2e_api_full
+def test_api_report_fetch_by_id_after_scan(
+    web_api_server, http_client, initialized_session
+):
+    start = http_client.post(
+        f"{web_api_server}/api/scan/start",
+        json={
+            "session_id": initialized_session,
+            "url": "https://example.com",
+            "scan_mode": "quick",
+            "authorization_confirmed": True,
+        },
+        timeout=10,
+    )
+    assert start.status_code == 200
+
+    completed = poll_until_complete(web_api_server, http_client, initialized_session)
+    report_dir = completed.get("report_dir")
+    assert report_dir
+
+    reports_payload = http_client.get(f"{web_api_server}/api/reports", timeout=10).json()
+    reports = reports_payload.get("reports") or []
+    assert any(r.get("id") == report_dir for r in reports)
+
+    report = http_client.get(f"{web_api_server}/api/report/{report_dir}", timeout=10)
+    assert report.status_code == 200
+    payload = report.json()
+    assert payload.get("error") != "Report not found"
+    assert isinstance(payload.get("findings"), list)
+    assert payload.get("findings")

--- a/tests/e2e/api/test_v1_scan_routes_e2e.py
+++ b/tests/e2e/api/test_v1_scan_routes_e2e.py
@@ -1,0 +1,205 @@
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import jwt
+import pytest
+import requests
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_for_server(base_url: str, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            response = requests.get(f"{base_url}/status", timeout=5)
+            if response.status_code in (200, 401, 404):
+                return
+        except Exception:
+            pass
+        time.sleep(0.25)
+    raise RuntimeError(f"Server did not start at {base_url}")
+
+
+def _poll_v1_scan_complete(
+    base_url: str, headers: dict, scan_id: str, timeout: float = 20.0
+) -> dict:
+    deadline = time.time() + timeout
+    last_payload = None
+    while time.time() < deadline:
+        resp = requests.get(f"{base_url}/api/v1/scans/{scan_id}", headers=headers, timeout=10)
+        assert resp.status_code == 200
+        payload = resp.json()
+        last_payload = payload
+        scan = payload.get("scan") or {}
+        if scan.get("is_running") is False and scan.get("progress", 0) >= 100:
+            return payload
+        time.sleep(0.25)
+    raise AssertionError(f"v1 scan did not complete. Last payload={last_payload}")
+
+
+def _auth_headers(secret: str, iss: str, sub: str, email: str) -> dict:
+    token = jwt.encode(
+        {"sub": sub, "email": email, "iss": iss},
+        secret,
+        algorithm="HS256",
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="module")
+def v1_server():
+    port = _free_port()
+    db_path = os.path.join("/tmp", f"vpt_e2e_v1_{port}.db")
+    if os.path.exists(db_path):
+        os.remove(db_path)
+
+    supabase_secret = "v1-e2e-secret-key-with-at-least-32-bytes"
+    supabase_iss = "https://v1-e2e.supabase.test/auth/v1"
+    env = os.environ.copy()
+    env.update(
+        {
+            "VPT_TEST_PORT": str(port),
+            "VPT_E2E_MODE": "1",
+            "VPT_HOSTED_MODE": "0",
+            "VPT_ALLOW_UNVERIFIED_WEBHOOKS": "1",
+            "VPT_BILLING_DB_PATH": db_path,
+            "SUPABASE_JWT_SECRET": supabase_secret,
+            "SUPABASE_URL": "https://v1-e2e.supabase.test",
+            "SUPABASE_JWT_ISS": supabase_iss,
+            "PYTHONUNBUFFERED": "1",
+        }
+    )
+
+    code = (
+        "import os;"
+        "from web_api import create_app;"
+        "app=create_app();"
+        "app.run(host='127.0.0.1', port=int(os.environ['VPT_TEST_PORT']), debug=False, use_reloader=False)"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_for_server(base_url)
+        yield {
+            "base_url": base_url,
+            "supabase_secret": supabase_secret,
+            "supabase_iss": supabase_iss,
+        }
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.mark.e2e_api_full
+def test_v1_scan_requires_auth(v1_server):
+    base_url = v1_server["base_url"]
+    response = requests.post(
+        f"{base_url}/api/v1/scans",
+        json={"url": "https://example.com", "scan_mode": "quick"},
+        timeout=10,
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.e2e_api_full
+def test_v1_scan_create_status_and_report(v1_server):
+    base_url = v1_server["base_url"]
+    headers = _auth_headers(
+        v1_server["supabase_secret"],
+        v1_server["supabase_iss"],
+        "user-a",
+        "user-a@example.com",
+    )
+
+    create = requests.post(
+        f"{base_url}/api/v1/scans",
+        json={"url": "https://example.com", "scan_mode": "quick"},
+        headers=headers,
+        timeout=10,
+    )
+    assert create.status_code == 201
+    create_payload = create.json()
+    scan_id = ((create_payload.get("scan") or {}).get("id"))
+    assert scan_id
+
+    completed = _poll_v1_scan_complete(base_url, headers, scan_id)
+    scan = completed.get("scan") or {}
+    assert scan.get("is_running") is False
+    assert scan.get("progress") == 100
+
+    # Report can transiently be 202 while report_dir syncs; poll briefly for 200.
+    deadline = time.time() + 10.0
+    report_resp = None
+    while time.time() < deadline:
+        report_resp = requests.get(
+            f"{base_url}/api/v1/scans/{scan_id}/report",
+            headers=headers,
+            timeout=10,
+        )
+        if report_resp.status_code == 200:
+            break
+        assert report_resp.status_code == 202
+        time.sleep(0.25)
+
+    assert report_resp is not None
+    assert report_resp.status_code == 200
+    report_payload = report_resp.json()
+    report = report_payload.get("report") or {}
+    assert report.get("findings") or report.get("markdown")
+
+
+@pytest.mark.e2e_api_full
+def test_v1_scan_enforces_org_ownership(v1_server):
+    base_url = v1_server["base_url"]
+    user_a_headers = _auth_headers(
+        v1_server["supabase_secret"],
+        v1_server["supabase_iss"],
+        "owner-user",
+        "owner@example.com",
+    )
+    user_b_headers = _auth_headers(
+        v1_server["supabase_secret"],
+        v1_server["supabase_iss"],
+        "other-user",
+        "other@example.com",
+    )
+
+    create = requests.post(
+        f"{base_url}/api/v1/scans",
+        json={"url": "https://example.com", "scan_mode": "quick"},
+        headers=user_a_headers,
+        timeout=10,
+    )
+    assert create.status_code == 201
+    scan_id = (create.json().get("scan") or {}).get("id")
+    assert scan_id
+
+    other_status = requests.get(
+        f"{base_url}/api/v1/scans/{scan_id}",
+        headers=user_b_headers,
+        timeout=10,
+    )
+    assert other_status.status_code == 404
+
+    other_report = requests.get(
+        f"{base_url}/api/v1/scans/{scan_id}/report",
+        headers=user_b_headers,
+        timeout=10,
+    )
+    assert other_report.status_code == 404

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,10 +17,11 @@ def _free_port() -> int:
 
 def _wait_for_server(base_url: str, timeout: float = 30.0) -> None:
     deadline = time.time() + timeout
+    request_timeout = float(os.environ.get("VPT_E2E_STARTUP_REQUEST_TIMEOUT", "5"))
     last_err = None
     while time.time() < deadline:
         try:
-            response = requests.get(f"{base_url}/status", timeout=2)
+            response = requests.get(f"{base_url}/status", timeout=request_timeout)
             if response.status_code in (200, 401, 404):
                 return
         except Exception as err:  # pragma: no cover - startup timing

--- a/tests/e2e/frontend/test_frontend_error_cancel_recovery_spec.py
+++ b/tests/e2e/frontend/test_frontend_error_cancel_recovery_spec.py
@@ -17,11 +17,14 @@ def test_frontend_cancel_and_retry_flow(web_api_server):
             page.select_option("#scan_mode", "quick")
             page.check("#authorization_confirmed")
             page.click("#start-scan-btn")
-            page.wait_for_timeout(1000)
+            page.wait_for_selector("#scan-status-panel:not(.d-none)", timeout=30000)
 
             page.on("dialog", lambda d: d.accept())
             page.click("#cancel-btn")
-            page.wait_for_timeout(1000)
+            page.wait_for_function(
+                "() => !document.querySelector('#start-scan-btn').disabled",
+                timeout=30000,
+            )
 
             # Start button should be enabled again after reset.
             assert not page.is_disabled("#start-scan-btn")
@@ -34,7 +37,7 @@ def test_frontend_cancel_and_retry_flow(web_api_server):
 
             page.check("#authorization_confirmed")
             page.click("#start-scan-btn")
-            page.wait_for_timeout(1500)
+            page.wait_for_selector("#scan-status-panel:not(.d-none)", timeout=30000)
             assert page.locator("#scan-status-panel").count() == 1
         finally:
             browser.close()
@@ -53,7 +56,7 @@ def test_frontend_paywall_after_first_free_scan(web_api_server):
             page.select_option("#scan_mode", "quick")
             page.check("#authorization_confirmed")
             page.click("#start-scan-btn")
-            page.wait_for_timeout(3500)
+            page.wait_for_selector("#report-container:not(.d-none)", timeout=60000)
 
             # Start a second quick scan in same account/session to trigger paywall.
             page.click("#new-scan-btn")
@@ -62,7 +65,7 @@ def test_frontend_paywall_after_first_free_scan(web_api_server):
             page.select_option("#scan_mode", "quick")
             page.check("#authorization_confirmed")
             page.click("#start-scan-btn")
-            page.wait_for_timeout(1200)
+            page.wait_for_selector("#paywall-alert:not(.d-none)", timeout=30000)
 
             classes = page.get_attribute("#paywall-alert", "class") or ""
             assert "d-none" not in classes

--- a/tests/e2e/frontend/test_frontend_scan_flow_spec.py
+++ b/tests/e2e/frontend/test_frontend_scan_flow_spec.py
@@ -18,10 +18,7 @@ def test_frontend_one_click_quick_scan_flow(web_api_server):
             page.click("#start-scan-btn")
 
             page.wait_for_selector("#scan-status-panel", timeout=10000)
-            page.wait_for_timeout(5000)
-
-            # In deterministic mode the report should become available quickly.
-            classes = page.get_attribute("#report-container", "class") or ""
-            assert "d-none" not in classes
+            # Wait until the report panel is actually revealed.
+            page.wait_for_selector("#report-container:not(.d-none)", timeout=30000)
         finally:
             browser.close()

--- a/tests/e2e/frontend/test_frontend_state_restore_spec.py
+++ b/tests/e2e/frontend/test_frontend_state_restore_spec.py
@@ -16,10 +16,19 @@ def test_frontend_state_restore_after_reload(web_api_server):
             page.select_option("#scan_mode", "quick")
             page.check("#authorization_confirmed")
             page.click("#start-scan-btn")
+            page.wait_for_selector("#scan-status-panel:not(.d-none)", timeout=30000)
 
-            page.wait_for_timeout(1000)
             page.reload(wait_until="networkidle")
-            page.wait_for_timeout(2500)
+            page.wait_for_function(
+                """() => {
+                    const isVisible = (selector) => {
+                        const el = document.querySelector(selector);
+                        return !!el && !el.classList.contains('d-none');
+                    };
+                    return isVisible('#scan-status-panel') || isVisible('#report-container');
+                }""",
+                timeout=45000,
+            )
 
             status_classes = page.get_attribute("#scan-status-panel", "class") or ""
             report_classes = page.get_attribute("#report-container", "class") or ""

--- a/tests/e2e/live/test_live_scan_e2e.py
+++ b/tests/e2e/live/test_live_scan_e2e.py
@@ -1,0 +1,174 @@
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from typing import Dict
+
+import pytest
+import requests
+from werkzeug.serving import make_server
+
+from tests.fixtures.vuln_app.app import create_app
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_for_server(url: str, timeout: float = 15.0) -> None:
+    deadline = time.time() + timeout
+    last_err = None
+    while time.time() < deadline:
+        try:
+            resp = requests.get(url, timeout=2)
+            if resp.status_code in (200, 404):
+                return
+        except Exception as err:  # pragma: no cover - startup timing
+            last_err = err
+        time.sleep(0.25)
+    raise RuntimeError(f"Server did not start at {url}: {last_err}")
+
+
+def _spawn_flask_process(
+    module_expr: str, port: int, extra_env: Dict[str, str]
+) -> subprocess.Popen:
+    env = os.environ.copy()
+    env.update(extra_env)
+    env["VPT_TEST_PORT"] = str(port)
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    code = (
+        "import os;"
+        f"{module_expr};"
+        "app.run(host='127.0.0.1', port=int(os.environ['VPT_TEST_PORT']), debug=False, use_reloader=False)"
+    )
+    return subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        env=env,
+    )
+
+
+class _WsgiServerThread(threading.Thread):
+    def __init__(self, host: str, port: int, app):
+        super().__init__(daemon=True)
+        self._server = make_server(host, port, app)
+
+    def run(self) -> None:  # pragma: no cover - thread wrapper
+        self._server.serve_forever()
+
+    def shutdown(self) -> None:
+        self._server.shutdown()
+
+
+def _poll_until_done(
+    base_url: str, client: requests.Session, session_id: str, timeout: float
+):
+    deadline = time.time() + timeout
+    last_payload = None
+    while time.time() < deadline:
+        resp = client.get(
+            f"{base_url}/status", params={"session_id": session_id}, timeout=10
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        last_payload = payload
+        if payload.get("is_running") is False and payload.get("progress", 0) >= 100:
+            return payload
+        time.sleep(1.0)
+    raise AssertionError(
+        f"Live scan did not complete within timeout. Last payload={last_payload}"
+    )
+
+
+@pytest.mark.e2e_live_scan
+def test_live_scan_end_to_end():
+    if os.environ.get("VPT_LIVE_E2E") != "1":
+        pytest.skip("Set VPT_LIVE_E2E=1 to enable live scan tests")
+
+    # Start a tiny local target app.
+    target_port = _free_port()
+    target_app = create_app()
+    target_server = _WsgiServerThread("127.0.0.1", target_port, target_app)
+    target_server.start()
+    target_base = f"http://127.0.0.1:{target_port}"
+    _wait_for_server(f"{target_base}/", timeout=10.0)
+
+    # Start web_api with hosted mode disabled so localhost targets are allowed.
+    api_port = _free_port()
+    api_db_path = os.path.join("/tmp", f"vpt_live_e2e_web_api_{api_port}.db")
+    if os.path.exists(api_db_path):
+        os.remove(api_db_path)
+    proc = _spawn_flask_process(
+        "from web_api import create_app; app=create_app()",
+        api_port,
+        {
+            "VPT_HOSTED_MODE": "0",
+            "VPT_ALLOW_UNVERIFIED_WEBHOOKS": "1",
+            "VPT_BILLING_DB_PATH": api_db_path,
+        },
+    )
+    api_base = f"http://127.0.0.1:{api_port}"
+    try:
+        _wait_for_server(f"{api_base}/status", timeout=30.0)
+
+        with requests.Session() as client:
+            # Create session
+            resp = client.post(
+                f"{api_base}/api/session/init",
+                json={"client_id": "live-e2e"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            session_id = resp.json().get("session_id")
+            assert session_id
+
+            # Start scan using the offline mock provider to avoid paid keys.
+            resp = client.post(
+                f"{api_base}/api/scan/start",
+                json={
+                    "session_id": session_id,
+                    "url": target_base,
+                    "scan_mode": "quick",
+                    "config": {
+                        "provider": "mock",
+                        "model": "mock",
+                        "scope": "url",
+                    },
+                },
+                timeout=30,
+            )
+            resp.raise_for_status()
+
+            # Poll until the scan completes.
+            status = _poll_until_done(
+                api_base, client, session_id, timeout=240.0
+            )
+            assert status.get("current_task") == "completed", status
+            assert status.get("report_available") is True, status
+
+            reports_resp = client.get(f"{api_base}/api/reports", timeout=20)
+            reports_resp.raise_for_status()
+            reports = reports_resp.json().get("reports", [])
+            assert reports, reports_resp.json()
+            report_id = reports[0].get("id")
+            assert report_id
+
+            report_resp = client.get(f"{api_base}/api/report/{report_id}", timeout=20)
+            report_resp.raise_for_status()
+            report = report_resp.json()
+            assert "error" not in report
+            assert report.get("findings") or report.get("markdown"), report
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - cleanup timing
+            proc.kill()
+        target_server.shutdown()
+

--- a/tests/fixtures/vuln_app/app.py
+++ b/tests/fixtures/vuln_app/app.py
@@ -1,0 +1,71 @@
+from flask import Flask, jsonify, request
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/")
+    def index():
+        return (
+            """
+            <html>
+              <head><title>VPT Fixture App</title></head>
+              <body>
+                <h1>VPT Fixture App</h1>
+                <p><a href="/page2">Page 2</a></p>
+                <p><a href="/echo?q=hello">Echo (q=hello)</a></p>
+                <form action="/submit" method="post">
+                  <input name="name" value="alice" />
+                  <button type="submit">Submit</button>
+                </form>
+              </body>
+            </html>
+            """,
+            200,
+            {"Content-Type": "text/html; charset=utf-8"},
+        )
+
+    @app.get("/page2")
+    def page2():
+        return (
+            """
+            <html>
+              <head><title>VPT Fixture App - Page 2</title></head>
+              <body>
+                <h2>Page 2</h2>
+                <p><a href="/echo?q=page2">Echo (q=page2)</a></p>
+              </body>
+            </html>
+            """,
+            200,
+            {"Content-Type": "text/html; charset=utf-8"},
+        )
+
+    @app.get("/echo")
+    def echo():
+        q = request.args.get("q", "")
+        # Intentionally reflect user input to provide predictable scanner surface area.
+        return (
+            f"<html><body><pre>ECHO:{q}</pre></body></html>",
+            200,
+            {"Content-Type": "text/html; charset=utf-8"},
+        )
+
+    @app.post("/submit")
+    def submit():
+        name = request.form.get("name", "")
+        return (
+            f"<html><body>SUBMIT:{name}</body></html>",
+            200,
+            {"Content-Type": "text/html; charset=utf-8"},
+        )
+
+    @app.get("/api/hello")
+    def api_hello():
+        return jsonify({"ok": True, "message": "hello"})
+
+    return app
+
+
+app = create_app()
+

--- a/tests/unit/test_scan_controller_exec.py
+++ b/tests/unit/test_scan_controller_exec.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+
+def test_scan_controller_uses_sys_executable_for_main_subprocess(monkeypatch, tmp_path):
+    from utils.report_manager import ReportManager
+    from utils.scan_controller import ScanController
+    from utils.session_manager import SessionManager
+
+    report_root = tmp_path / "reports"
+    report_manager = ReportManager(str(report_root))
+    session_manager = SessionManager(session_file=str(tmp_path / "sessions.json"))
+    controller = ScanController(session_manager, report_manager)
+
+    report_dir = report_manager.create_report_directory("https://example.com")
+
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return object()
+
+    monkeypatch.setattr(
+        __import__("subprocess"),
+        "Popen",
+        fake_popen,
+    )
+    monkeypatch.setattr(controller, "_monitor_process", lambda *_args, **_kwargs: None)
+
+    controller._execute_scan(
+        url="https://example.com",
+        config={},
+        report_dir=report_dir,
+        progress_callback=lambda *_args, **_kwargs: None,
+    )
+
+    assert captured["cmd"][0] == sys.executable
+    assert captured["cmd"][1:] == [
+        "main.py",
+        "--url",
+        "https://example.com",
+        "--output",
+        os.path.join(str(report_root), report_dir),
+    ]
+

--- a/utils/activity_tracker_postgres.py
+++ b/utils/activity_tracker_postgres.py
@@ -1,0 +1,235 @@
+import json
+import logging
+import re
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+
+class PostgresActivityTracker:
+    """Postgres-backed ActivityTracker (Supabase-compatible)."""
+
+    def __init__(self, db_url: str):
+        self.db_url = db_url
+        self._lock = threading.Lock()
+        self._logger = logging.getLogger("web_ui")
+        self._init_schema()
+
+    def _connect(self):
+        try:
+            import psycopg  # type: ignore
+            from psycopg.rows import dict_row  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "PostgresActivityTracker requires psycopg. Install with: pip install 'psycopg[binary]'"
+            ) from exc
+        return psycopg.connect(self.db_url, row_factory=dict_row)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            # Ensure sessions table exists even if PostgresSessionManager wasn't initialized first.
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    last_activity DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS activities (
+                    id BIGSERIAL PRIMARY KEY,
+                    session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+                    timestamp DOUBLE PRECISION NOT NULL,
+                    time_text TEXT NOT NULL,
+                    type TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    agent TEXT,
+                    details JSONB
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_activities_session_time ON activities(session_id, id DESC)"
+            )
+            conn.commit()
+
+    def _clean_description(self, description: str) -> str:
+        description = (description or "").strip()
+        description = re.sub(r"\s*Activity\s*$", "", description)
+        description = re.sub(r"\'}]\}.*?$", "", description)
+        description = re.sub(
+            r"(\(Agent:\s*[^)]+\))\s*(\(Agent:.*?\))+", r"\1", description
+        )
+        return description
+
+    def _coerce_json(self, value: Any, default: Any) -> Any:
+        if value is None:
+            return default
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode("utf-8", errors="ignore")
+            except Exception:
+                return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except Exception:
+                return default
+        return default
+
+    def _is_duplicate_activity(
+        self,
+        conn,
+        session_id: str,
+        activity_type: str,
+        description: str,
+        agent_name: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        # Mimic in-memory tracker: last 10 activities, 5s window.
+        recent_timeframe = 5.0
+        now = time.time()
+        rows = conn.execute(
+            """
+            SELECT id, timestamp, time_text, type, description, agent, details
+            FROM activities
+            WHERE session_id = %s
+            ORDER BY id DESC
+            LIMIT 10
+            """,
+            (session_id,),
+        ).fetchall()
+
+        description_fingerprint = (
+            description[-100:] if len(description) > 100 else description
+        )
+
+        for row in rows:
+            if now - float(row.get("timestamp") or 0) > recent_timeframe:
+                continue
+            if row.get("type") != activity_type:
+                continue
+            existing_desc = row.get("description") or ""
+            existing_fingerprint = (
+                existing_desc[-100:] if len(existing_desc) > 100 else existing_desc
+            )
+            if existing_fingerprint == description_fingerprint and row.get("agent") == agent_name:
+                payload = dict(row)
+                payload["details"] = self._coerce_json(payload.get("details"), {})
+                return payload
+        return None
+
+    def _prune_activities(self, conn, session_id: str) -> None:
+        # Keep the newest 200.
+        conn.execute(
+            """
+            DELETE FROM activities
+            WHERE session_id = %s
+              AND id NOT IN (
+                SELECT id FROM activities
+                WHERE session_id = %s
+                ORDER BY id DESC
+                LIMIT 200
+              )
+            """,
+            (session_id, session_id),
+        )
+
+    def add_activity(
+        self,
+        session_id: str,
+        activity_type: str,
+        description: str,
+        details: Optional[Dict[str, Any]] = None,
+        agent_name: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        description = self._clean_description(description)
+        now = time.time()
+        time_text = time.strftime("%H:%M:%S")
+
+        with self._lock:
+            with self._connect() as conn:
+                # Ensure session row exists so the FK does not fail.
+                conn.execute(
+                    """
+                    INSERT INTO sessions(session_id, created_at, last_activity)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (session_id) DO NOTHING
+                    """,
+                    (session_id, now, now),
+                )
+                dup = self._is_duplicate_activity(
+                    conn, session_id, activity_type, description, agent_name
+                )
+                if dup is not None:
+                    conn.commit()
+                    return dup
+
+                conn.execute(
+                    """
+                    INSERT INTO activities(session_id, timestamp, time_text, type, description, agent, details)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s::jsonb)
+                    """,
+                    (
+                        session_id,
+                        now,
+                        time_text,
+                        activity_type,
+                        description,
+                        agent_name,
+                        json.dumps(details or {}),
+                    ),
+                )
+                self._prune_activities(conn, session_id)
+                conn.commit()
+
+        activity = {
+            "timestamp": now,
+            "time": time_text,
+            "type": activity_type,
+            "description": description,
+            "agent": agent_name,
+        }
+        if details:
+            activity["details"] = details
+        return activity
+
+    def get_activities(self, session_id: str) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT timestamp, time_text, type, description, agent, details
+                FROM activities
+                WHERE session_id = %s
+                ORDER BY id ASC
+                """,
+                (session_id,),
+            ).fetchall()
+
+        activities: List[Dict[str, Any]] = []
+        for row in rows:
+            payload = {
+                "timestamp": row.get("timestamp"),
+                "time": row.get("time_text"),
+                "type": row.get("type"),
+                "description": row.get("description"),
+                "agent": row.get("agent"),
+            }
+            details = self._coerce_json(row.get("details"), None)
+            if details is not None:
+                payload["details"] = details
+            activities.append(payload)
+        return activities
+
+    def clear_activities(self, session_id: str) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "DELETE FROM activities WHERE session_id = %s",
+                    (session_id,),
+                )
+                conn.commit()

--- a/utils/billing_store.py
+++ b/utils/billing_store.py
@@ -290,6 +290,7 @@ class BillingStore:
         now = time.time()
         with self._lock:
             with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
                 conn.execute(
                     """
                     UPDATE entitlements
@@ -306,6 +307,7 @@ class BillingStore:
         pro_until = (now + timedelta(days=days)).isoformat()
         with self._lock:
             with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
                 conn.execute(
                     "UPDATE entitlements SET pro_until = ?, updated_at = ? WHERE account_id = ?",
                     (pro_until, time.time(), account_id),

--- a/utils/billing_store_postgres.py
+++ b/utils/billing_store_postgres.py
@@ -1,0 +1,488 @@
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+
+class PostgresBillingStore:
+    """Postgres-backed billing and entitlement persistence (Supabase-compatible)."""
+
+    def __init__(self, db_url: str):
+        self.db_url = db_url
+        self._lock = threading.Lock()
+        self._init_schema()
+
+    def _connect(self):
+        try:
+            import psycopg  # type: ignore
+            from psycopg.rows import dict_row  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "PostgresBillingStore requires psycopg. Install with: pip install 'psycopg[binary]'"
+            ) from exc
+        return psycopg.connect(self.db_url, row_factory=dict_row)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS accounts (
+                    account_id TEXT PRIMARY KEY,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS entitlements (
+                    account_id TEXT PRIMARY KEY REFERENCES accounts(account_id),
+                    free_scans_remaining INTEGER NOT NULL DEFAULT 1,
+                    deep_scan_credits INTEGER NOT NULL DEFAULT 0,
+                    pro_until TEXT,
+                    updated_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS usage_events (
+                    id BIGSERIAL PRIMARY KEY,
+                    account_id TEXT,
+                    ip TEXT,
+                    event_type TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS checkout_sessions (
+                    checkout_session_id TEXT PRIMARY KEY,
+                    account_id TEXT NOT NULL,
+                    scan_mode TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    price_id TEXT,
+                    amount INTEGER,
+                    currency TEXT,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    updated_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS payments (
+                    id BIGSERIAL PRIMARY KEY,
+                    payment_intent_id TEXT,
+                    checkout_session_id TEXT,
+                    account_id TEXT,
+                    status TEXT,
+                    amount INTEGER,
+                    currency TEXT,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_usage_events_account_type_time
+                ON usage_events(account_id, event_type, created_at)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_usage_events_ip_type_time
+                ON usage_events(ip, event_type, created_at)
+                """
+            )
+            conn.commit()
+
+    def _is_pro_active(self, pro_until: Optional[str]) -> bool:
+        if not pro_until:
+            return False
+        try:
+            return datetime.fromisoformat(pro_until).replace(
+                tzinfo=timezone.utc
+            ) > datetime.now(timezone.utc)
+        except Exception:
+            return False
+
+    def _entitlements_from_row(
+        self, account_id: str, row: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        if not row:
+            return {
+                "account_id": account_id,
+                "free_scans_remaining": 0,
+                "deep_scan_credits": 0,
+                "pro_until": None,
+                "pro_active": False,
+            }
+        pro_until = row.get("pro_until")
+        return {
+            "account_id": account_id,
+            "free_scans_remaining": int(row.get("free_scans_remaining", 0)),
+            "deep_scan_credits": int(row.get("deep_scan_credits", 0)),
+            "pro_until": pro_until,
+            "pro_active": self._is_pro_active(pro_until),
+        }
+
+    def _ensure_account_locked(self, conn, account_id: str) -> None:
+        now = time.time()
+        conn.execute(
+            """
+            INSERT INTO accounts(account_id, created_at) VALUES (%s, %s)
+            ON CONFLICT (account_id) DO NOTHING
+            """,
+            (account_id, now),
+        )
+        conn.execute(
+            """
+            INSERT INTO entitlements(account_id, free_scans_remaining, deep_scan_credits, pro_until, updated_at)
+            VALUES (%s, 1, 0, NULL, %s)
+            ON CONFLICT (account_id) DO NOTHING
+            """,
+            (account_id, now),
+        )
+
+    def ensure_account(self, account_id: str) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
+                conn.commit()
+
+    def get_entitlements(self, account_id: str) -> Dict[str, Any]:
+        self.ensure_account(account_id)
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT free_scans_remaining, deep_scan_credits, pro_until FROM entitlements WHERE account_id = %s",
+                (account_id,),
+            ).fetchone()
+        return self._entitlements_from_row(account_id, row)
+
+    def try_consume_entitlement_for_scan(
+        self, account_id: str, scan_mode: str
+    ) -> Dict[str, Any]:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
+
+                row = conn.execute(
+                    """
+                    SELECT free_scans_remaining, deep_scan_credits, pro_until
+                    FROM entitlements
+                    WHERE account_id = %s
+                    FOR UPDATE
+                    """,
+                    (account_id,),
+                ).fetchone()
+                entitlements = self._entitlements_from_row(account_id, row)
+
+                if entitlements["pro_active"]:
+                    conn.commit()
+                    return {
+                        "allowed": True,
+                        "consume": None,
+                        "entitlements": entitlements,
+                    }
+
+                if scan_mode == "quick":
+                    updated = conn.execute(
+                        """
+                        UPDATE entitlements
+                        SET free_scans_remaining = free_scans_remaining - 1,
+                            updated_at = %s
+                        WHERE account_id = %s AND free_scans_remaining > 0
+                        """,
+                        (now, account_id),
+                    )
+                    if updated.rowcount == 1:
+                        consumed_row = conn.execute(
+                            "SELECT free_scans_remaining, deep_scan_credits, pro_until FROM entitlements WHERE account_id = %s",
+                            (account_id,),
+                        ).fetchone()
+                        conn.commit()
+                        return {
+                            "allowed": True,
+                            "consume": "free",
+                            "entitlements": self._entitlements_from_row(
+                                account_id, consumed_row
+                            ),
+                        }
+
+                updated = conn.execute(
+                    """
+                    UPDATE entitlements
+                    SET deep_scan_credits = deep_scan_credits - 1,
+                        updated_at = %s
+                    WHERE account_id = %s AND deep_scan_credits > 0
+                    """,
+                    (now, account_id),
+                )
+                if updated.rowcount == 1:
+                    consumed_row = conn.execute(
+                        "SELECT free_scans_remaining, deep_scan_credits, pro_until FROM entitlements WHERE account_id = %s",
+                        (account_id,),
+                    ).fetchone()
+                    conn.commit()
+                    return {
+                        "allowed": True,
+                        "consume": "credit",
+                        "entitlements": self._entitlements_from_row(
+                            account_id, consumed_row
+                        ),
+                    }
+
+                conn.commit()
+                return {"allowed": False, "consume": None, "entitlements": entitlements}
+
+    def refund_consumption(self, account_id: str, consume: Optional[str]) -> None:
+        if consume not in {"free", "credit"}:
+            return
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
+                if consume == "free":
+                    conn.execute(
+                        """
+                        UPDATE entitlements
+                        SET free_scans_remaining = free_scans_remaining + 1,
+                            updated_at = %s
+                        WHERE account_id = %s
+                        """,
+                        (now, account_id),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        UPDATE entitlements
+                        SET deep_scan_credits = deep_scan_credits + 1,
+                            updated_at = %s
+                        WHERE account_id = %s
+                        """,
+                        (now, account_id),
+                    )
+                conn.commit()
+
+    def decrement_free_scan(self, account_id: str) -> None:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    UPDATE entitlements
+                    SET free_scans_remaining = GREATEST(free_scans_remaining - 1, 0),
+                        updated_at = %s
+                    WHERE account_id = %s
+                    """,
+                    (now, account_id),
+                )
+                conn.commit()
+
+    def decrement_credit(self, account_id: str) -> None:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    UPDATE entitlements
+                    SET deep_scan_credits = GREATEST(deep_scan_credits - 1, 0),
+                        updated_at = %s
+                    WHERE account_id = %s
+                    """,
+                    (now, account_id),
+                )
+                conn.commit()
+
+    def add_credits(self, account_id: str, credits: int) -> None:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
+                conn.execute(
+                    """
+                    UPDATE entitlements
+                    SET deep_scan_credits = deep_scan_credits + %s,
+                        updated_at = %s
+                    WHERE account_id = %s
+                    """,
+                    (int(credits), now, account_id),
+                )
+                conn.commit()
+
+    def activate_pro(self, account_id: str, days: int = 30) -> str:
+        now = datetime.now(timezone.utc)
+        pro_until = (now + timedelta(days=days)).isoformat()
+        with self._lock:
+            with self._connect() as conn:
+                self._ensure_account_locked(conn, account_id)
+                conn.execute(
+                    "UPDATE entitlements SET pro_until = %s, updated_at = %s WHERE account_id = %s",
+                    (pro_until, time.time(), account_id),
+                )
+                conn.commit()
+        return pro_until
+
+    def create_checkout_session(
+        self,
+        checkout_session_id: str,
+        account_id: str,
+        scan_mode: str,
+        price_id: Optional[str] = None,
+        amount: Optional[int] = None,
+        currency: str = "usd",
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO checkout_sessions(
+                        checkout_session_id, account_id, scan_mode, status, price_id, amount, currency, created_at, updated_at
+                    )
+                    VALUES (%s, %s, %s, 'open', %s, %s, %s, %s, %s)
+                    ON CONFLICT (checkout_session_id) DO UPDATE SET
+                        account_id = EXCLUDED.account_id,
+                        scan_mode = EXCLUDED.scan_mode,
+                        status = 'open',
+                        price_id = EXCLUDED.price_id,
+                        amount = EXCLUDED.amount,
+                        currency = EXCLUDED.currency,
+                        created_at = EXCLUDED.created_at,
+                        updated_at = EXCLUDED.updated_at
+                    """,
+                    (
+                        checkout_session_id,
+                        account_id,
+                        scan_mode,
+                        price_id,
+                        amount,
+                        currency,
+                        now,
+                        now,
+                    ),
+                )
+                conn.commit()
+
+    def get_checkout_session(
+        self, checkout_session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM checkout_sessions WHERE checkout_session_id = %s",
+                (checkout_session_id,),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def mark_checkout_completed(
+        self, checkout_session_id: str
+    ) -> Optional[Dict[str, Any]]:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    """
+                    SELECT * FROM checkout_sessions
+                    WHERE checkout_session_id = %s
+                    FOR UPDATE
+                    """,
+                    (checkout_session_id,),
+                ).fetchone()
+                if not row:
+                    conn.commit()
+                    return None
+
+                if row.get("status") == "completed":
+                    payload = dict(row)
+                    payload["just_completed"] = False
+                    conn.commit()
+                    return payload
+
+                conn.execute(
+                    """
+                    UPDATE checkout_sessions
+                    SET status = 'completed',
+                        updated_at = %s
+                    WHERE checkout_session_id = %s
+                    """,
+                    (now, checkout_session_id),
+                )
+                updated = conn.execute(
+                    "SELECT * FROM checkout_sessions WHERE checkout_session_id = %s",
+                    (checkout_session_id,),
+                ).fetchone()
+                conn.commit()
+
+                payload = dict(updated) if updated else dict(row)
+                payload["just_completed"] = True
+                return payload
+
+    def record_payment(
+        self,
+        account_id: str,
+        checkout_session_id: str,
+        status: str,
+        amount: Optional[int] = None,
+        currency: str = "usd",
+        payment_intent_id: Optional[str] = None,
+    ) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO payments(payment_intent_id, checkout_session_id, account_id, status, amount, currency, created_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        payment_intent_id,
+                        checkout_session_id,
+                        account_id,
+                        status,
+                        amount,
+                        currency,
+                        time.time(),
+                    ),
+                )
+                conn.commit()
+
+    def record_usage_event(self, account_id: str, ip: str, event_type: str) -> None:
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO usage_events(account_id, ip, event_type, created_at) VALUES (%s, %s, %s, %s)",
+                    (account_id, ip, event_type, time.time()),
+                )
+                conn.commit()
+
+    def count_recent_events_by_account(
+        self, account_id: str, event_type: str, window_seconds: int
+    ) -> int:
+        since = time.time() - window_seconds
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                FROM usage_events
+                WHERE account_id = %s AND event_type = %s AND created_at >= %s
+                """,
+                (account_id, event_type, since),
+            ).fetchone()
+        return int(row["c"]) if row else 0
+
+    def count_recent_events_by_ip(
+        self, ip: str, event_type: str, window_seconds: int
+    ) -> int:
+        since = time.time() - window_seconds
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                FROM usage_events
+                WHERE ip = %s AND event_type = %s AND created_at >= %s
+                """,
+                (ip, event_type, since),
+            ).fetchone()
+        return int(row["c"]) if row else 0
+

--- a/utils/postgres_json.py
+++ b/utils/postgres_json.py
@@ -1,0 +1,21 @@
+import json
+from typing import Any
+
+
+def coerce_json_value(value: Any, default: Any) -> Any:
+    """Normalize DB JSON/JSONB values to Python objects with a safe default."""
+    if value is None:
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        try:
+            value = value.decode("utf-8", errors="ignore")
+        except Exception:
+            return default
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except Exception:
+            return default
+    return default

--- a/utils/report_manager_postgres.py
+++ b/utils/report_manager_postgres.py
@@ -1,0 +1,324 @@
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class PostgresReportManager:
+    """Hybrid report manager: filesystem staging + Postgres persistence (Supabase-compatible)."""
+
+    def __init__(self, db_url: str, upload_folder: str):
+        self.db_url = db_url
+        self.upload_folder = upload_folder
+        self.logger = logging.getLogger("web_ui")
+        self.ensure_report_directory()
+        self._init_schema()
+
+    def _connect(self):
+        try:
+            import psycopg  # type: ignore
+            from psycopg.rows import dict_row  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "PostgresReportManager requires psycopg. Install with: pip install 'psycopg[binary]'"
+            ) from exc
+        return psycopg.connect(self.db_url, row_factory=dict_row)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS reports (
+                    report_id TEXT PRIMARY KEY,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    url TEXT,
+                    timestamp_text TEXT,
+                    report_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    report_md TEXT
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_reports_created_at ON reports(created_at DESC)"
+            )
+            conn.commit()
+
+    def _coerce_json(self, value: Any, default: Any) -> Any:
+        if value is None:
+            return default
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode("utf-8", errors="ignore")
+            except Exception:
+                return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except Exception:
+                return default
+        return default
+
+    def ensure_report_directory(self) -> None:
+        try:
+            os.makedirs(self.upload_folder, exist_ok=True)
+            self.logger.info(f"Ensured report directory exists: {self.upload_folder}")
+        except Exception as e:
+            self.logger.error(f"Failed to create report directory: {str(e)}")
+
+    # --- Filesystem staging (kept for scanner subprocess output) ---
+
+    def create_report_directory(self, url: str) -> str:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        safe_url = self._sanitize_url(url)
+        report_dir = f"{safe_url}_{timestamp}"
+        report_path = os.path.join(self.upload_folder, report_dir)
+        try:
+            os.makedirs(report_path, exist_ok=True)
+        except Exception as e:
+            self.logger.error(f"Error creating report directory: {str(e)}")
+        return report_dir
+
+    def _sanitize_url(self, url: str) -> str:
+        import re
+
+        url = re.sub(r"^https?://", "", url)
+        url = url.split("#")[0]
+        url = url.split("?")[0]
+        url = re.sub(r"[/\\\\]", "_", url)
+        url = re.sub(r'[*?:\"<>|]', "_", url)
+        url = re.sub(r"_+", "_", url)
+        return url.strip("_") or "target"
+
+    # --- Postgres persistence ---
+
+    def _upsert_report(self, report_id: str, url: Optional[str], report_json: Dict[str, Any], report_md: Optional[str]) -> None:
+        created_at = time.time()
+        timestamp_text = None
+        if isinstance(report_json, dict):
+            timestamp_text = report_json.get("timestamp") or report_json.get("generated_at")
+
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO reports(report_id, created_at, url, timestamp_text, report_json, report_md)
+                VALUES (%s, %s, %s, %s, %s::jsonb, %s)
+                ON CONFLICT (report_id) DO UPDATE SET
+                    url = COALESCE(EXCLUDED.url, reports.url),
+                    timestamp_text = COALESCE(EXCLUDED.timestamp_text, reports.timestamp_text),
+                    report_json = EXCLUDED.report_json,
+                    report_md = COALESCE(EXCLUDED.report_md, reports.report_md),
+                    created_at = GREATEST(reports.created_at, EXCLUDED.created_at)
+                """,
+                (
+                    report_id,
+                    created_at,
+                    url,
+                    timestamp_text,
+                    json.dumps(report_json or {}),
+                    report_md,
+                ),
+            )
+            conn.commit()
+
+    def ingest_report(self, report_id: str, url: Optional[str] = None) -> Dict[str, str]:
+        """Read report artifacts from filesystem staging and persist into Postgres."""
+        report_path = os.path.join(self.upload_folder, report_id, "report.json")
+        markdown_path = os.path.join(self.upload_folder, report_id, "report.md")
+
+        if not os.path.exists(report_path):
+            return {"status": "error", "message": "report.json not found"}
+
+        try:
+            with open(report_path, "r") as f:
+                report_json = json.load(f)
+        except Exception as e:
+            return {"status": "error", "message": f"failed to read report.json: {e}"}
+
+        report_md = None
+        if os.path.exists(markdown_path):
+            try:
+                with open(markdown_path, "r") as f:
+                    report_md = f.read()
+            except Exception:
+                report_md = None
+
+        self._upsert_report(report_id, url, report_json, report_md)
+        return {"status": "success", "report_id": report_id}
+
+    # --- API surface expected by routes ---
+
+    def get_report_list(self) -> List[Dict[str, Any]]:
+        reports: List[Dict[str, Any]] = []
+        try:
+            with self._connect() as conn:
+                rows = conn.execute(
+                    """
+                    SELECT report_id, created_at, url, timestamp_text, report_json
+                    FROM reports
+                    ORDER BY created_at DESC
+                    """
+                ).fetchall()
+        except Exception as e:
+            self.logger.error(f"Error listing reports from Postgres: {e}")
+            return reports
+
+        for row in rows:
+            report_id = row.get("report_id")
+            report_json = self._coerce_json(row.get("report_json"), {}) or {}
+            findings = report_json.get("findings") if isinstance(report_json, dict) else None
+            vuln_count = len(findings) if isinstance(findings, list) else 0
+
+            created_at = float(row.get("created_at") or 0)
+            date_str = ""
+            try:
+                date_str = datetime.fromtimestamp(created_at).strftime("%Y-%m-%d %H:%M:%S")
+            except Exception:
+                date_str = ""
+
+            reports.append(
+                {
+                    "id": report_id,
+                    "url": row.get("url") or report_json.get("url") or "Unknown URL",
+                    "timestamp": row.get("timestamp_text") or report_json.get("timestamp") or created_at,
+                    "date": date_str,
+                    "vulnerabilities": vuln_count,
+                }
+            )
+        return reports
+
+    def get_report(self, report_id: str) -> Dict[str, Any]:
+        # Prefer Postgres.
+        try:
+            with self._connect() as conn:
+                row = conn.execute(
+                    """
+                    SELECT report_json, report_md, url
+                    FROM reports
+                    WHERE report_id = %s
+                    """,
+                    (report_id,),
+                ).fetchone()
+        except Exception as e:
+            self.logger.error(f"Error fetching report {report_id} from Postgres: {e}")
+            row = None
+
+        if row:
+            report_json = self._coerce_json(row.get("report_json"), {}) or {}
+            if not isinstance(report_json, dict):
+                report_json = {"content": report_json}
+            report_md = row.get("report_md")
+            if report_md:
+                report_json["markdown"] = report_md
+            if row.get("url") and "url" not in report_json:
+                report_json["url"] = row.get("url")
+            return report_json
+
+        # Fallback to filesystem for backwards compatibility.
+        report_path = os.path.join(self.upload_folder, report_id, "report.json")
+        markdown_path = os.path.join(self.upload_folder, report_id, "report.md")
+
+        if not os.path.exists(report_path):
+            return {"error": "Report not found"}
+
+        try:
+            with open(report_path, "r") as f:
+                report_data = json.load(f)
+            if os.path.exists(markdown_path):
+                with open(markdown_path, "r") as f:
+                    report_data["markdown"] = f.read()
+            return report_data
+        except Exception as e:
+            self.logger.error(f"Error reading report {report_id}: {str(e)}")
+            return {"error": f"Error reading report: {str(e)}"}
+
+    def save_report(self, report_dir: str, report_data: Dict[str, Any]) -> Dict[str, str]:
+        """Write report artifacts to filesystem staging and upsert into Postgres."""
+        report_path = os.path.join(self.upload_folder, report_dir)
+        json_path = os.path.join(report_path, "report.json")
+        markdown_path = os.path.join(report_path, "report.md")
+
+        try:
+            os.makedirs(report_path, exist_ok=True)
+            with open(json_path, "w") as f:
+                json.dump(report_data, f, indent=2)
+
+            md = None
+            if "markdown" in report_data:
+                md = str(report_data.get("markdown") or "")
+                with open(markdown_path, "w") as f:
+                    f.write(md)
+
+            # Store a copy in Postgres (excluding markdown from the json file payload).
+            report_json = dict(report_data)
+            report_json.pop("markdown", None)
+            self._upsert_report(report_dir, report_data.get("url"), report_json, md)
+
+            return {
+                "status": "success",
+                "report_id": report_dir,
+                "json_path": json_path,
+                "markdown_path": markdown_path,
+            }
+        except Exception as e:
+            self.logger.error(f"Error saving report: {str(e)}")
+            return {"status": "error", "message": str(e)}
+
+    def seed_deterministic_report(
+        self, report_dir: str, url: str, scan_mode: str = "quick"
+    ) -> Dict[str, str]:
+        report_data = {
+            "status": "success",
+            "url": url,
+            "scan_mode": scan_mode,
+            "generated_by": "seed_deterministic_report",
+            "findings": [
+                {
+                    "name": "Reflected XSS",
+                    "severity": "high",
+                    "vulnerability_type": "Cross-Site Scripting (XSS)",
+                    "target": url,
+                    "details": {
+                        "payload": "<script>alert(1)</script>",
+                        "evidence": "Payload reflected in deterministic E2E fixture response",
+                    },
+                }
+            ],
+            "markdown": (
+                "# Deterministic E2E Report\n\n"
+                f"- Target: {url}\n"
+                f"- Scan mode: {scan_mode}\n"
+                "- Findings: 1\n"
+            ),
+        }
+        return self.save_report(report_dir, report_data)
+
+    def get_report_artifact_bytes(self, filename: str) -> Tuple[Optional[bytes], Optional[str]]:
+        """
+        Fetch known artifacts from Postgres for the /reports/<path:filename> route.
+        Supports: <report_id>/report.json, <report_id>/report.md
+        """
+        parts = [p for p in filename.split("/") if p]
+        if len(parts) < 2:
+            return None, None
+        report_id = parts[0]
+        leaf = parts[-1]
+        if leaf not in {"report.json", "report.md"}:
+            return None, None
+
+        report = self.get_report(report_id)
+        if report.get("error") == "Report not found":
+            return None, None
+
+        if leaf == "report.md":
+            md = report.get("markdown") or ""
+            return str(md).encode("utf-8"), "text/markdown; charset=utf-8"
+
+        # report.json should match the file artifact (exclude markdown).
+        payload = dict(report)
+        payload.pop("markdown", None)
+        return json.dumps(payload, indent=2).encode("utf-8"), "application/json; charset=utf-8"
+

--- a/utils/saas_store.py
+++ b/utils/saas_store.py
@@ -1,0 +1,233 @@
+import threading
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+
+class InMemorySaaSStore:
+    """Fallback SaaS ownership store for non-Postgres local/dev usage."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._users: Dict[str, Dict[str, Any]] = {}
+        self._user_org: Dict[str, str] = {}
+        self._memberships: Dict[str, Dict[str, str]] = {}
+        self._scans: Dict[str, Dict[str, Any]] = {}
+
+    def ensure_user_org(self, user_id: str, email: Optional[str] = None) -> Dict[str, str]:
+        with self._lock:
+            if user_id not in self._users:
+                self._users[user_id] = {
+                    "id": user_id,
+                    "email": email,
+                    "created_at": time.time(),
+                }
+            elif email and not self._users[user_id].get("email"):
+                self._users[user_id]["email"] = email
+
+            org_id = self._user_org.get(user_id)
+            if not org_id:
+                org_id = str(uuid.uuid4())
+                self._user_org[user_id] = org_id
+
+            org_members = self._memberships.setdefault(org_id, {})
+            org_members[user_id] = "owner"
+            return {"user_id": user_id, "org_id": org_id}
+
+    def create_scan(
+        self,
+        org_id: str,
+        created_by_user_id: str,
+        target_url: str,
+        mode: str,
+        session_id: str,
+        legacy_scan_id: str,
+    ) -> str:
+        with self._lock:
+            scan_id = str(uuid.uuid4())
+            self._scans[scan_id] = {
+                "id": scan_id,
+                "org_id": org_id,
+                "created_by_user_id": created_by_user_id,
+                "target_url": target_url,
+                "mode": mode,
+                "session_id": session_id,
+                "legacy_scan_id": legacy_scan_id,
+                "created_at": time.time(),
+            }
+            return scan_id
+
+    def get_scan_for_user(self, scan_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            scan = self._scans.get(scan_id)
+            if not scan:
+                return None
+            org_members = self._memberships.get(scan["org_id"], {})
+            if user_id not in org_members:
+                return None
+            return dict(scan)
+
+
+class PostgresSaaSStore:
+    """Postgres-backed SaaS ownership store (Supabase-compatible)."""
+
+    def __init__(self, db_url: str):
+        self.db_url = db_url
+        self._lock = threading.Lock()
+        self._init_schema()
+
+    def _connect(self):
+        try:
+            import psycopg  # type: ignore
+            from psycopg.rows import dict_row  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "PostgresSaaSStore requires psycopg. Install with: pip install 'psycopg[binary]'"
+            ) from exc
+        return psycopg.connect(self.db_url, row_factory=dict_row)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS orgs (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memberships (
+                    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    org_id TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+                    role TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    PRIMARY KEY (user_id, org_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS saas_scans (
+                    id TEXT PRIMARY KEY,
+                    org_id TEXT NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+                    created_by_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    target_url TEXT NOT NULL,
+                    mode TEXT NOT NULL,
+                    session_id TEXT NOT NULL,
+                    legacy_scan_id TEXT NOT NULL,
+                    created_at DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_memberships_user ON memberships(user_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_saas_scans_org_created ON saas_scans(org_id, created_at DESC)"
+            )
+            conn.commit()
+
+    def ensure_user_org(self, user_id: str, email: Optional[str] = None) -> Dict[str, str]:
+        now = time.time()
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO users(id, email, created_at)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (id) DO UPDATE SET
+                        email = COALESCE(users.email, EXCLUDED.email)
+                    """,
+                    (user_id, email, now),
+                )
+
+                membership = conn.execute(
+                    """
+                    SELECT org_id
+                    FROM memberships
+                    WHERE user_id = %s
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """,
+                    (user_id,),
+                ).fetchone()
+                if membership and membership.get("org_id"):
+                    conn.commit()
+                    return {"user_id": user_id, "org_id": str(membership["org_id"])}
+
+                org_id = str(uuid.uuid4())
+                org_name = f"{(email or user_id)[:32]} workspace"
+                conn.execute(
+                    "INSERT INTO orgs(id, name, created_at) VALUES (%s, %s, %s)",
+                    (org_id, org_name, now),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO memberships(user_id, org_id, role, created_at)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (user_id, org_id) DO NOTHING
+                    """,
+                    (user_id, org_id, "owner", now),
+                )
+                conn.commit()
+                return {"user_id": user_id, "org_id": org_id}
+
+    def create_scan(
+        self,
+        org_id: str,
+        created_by_user_id: str,
+        target_url: str,
+        mode: str,
+        session_id: str,
+        legacy_scan_id: str,
+    ) -> str:
+        now = time.time()
+        scan_id = str(uuid.uuid4())
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO saas_scans(
+                    id, org_id, created_by_user_id, target_url, mode, session_id, legacy_scan_id, created_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    scan_id,
+                    org_id,
+                    created_by_user_id,
+                    target_url,
+                    mode,
+                    session_id,
+                    legacy_scan_id,
+                    now,
+                ),
+            )
+            conn.commit()
+        return scan_id
+
+    def get_scan_for_user(self, scan_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT s.id, s.org_id, s.created_by_user_id, s.target_url, s.mode, s.session_id, s.legacy_scan_id, s.created_at
+                FROM saas_scans s
+                INNER JOIN memberships m ON m.org_id = s.org_id
+                WHERE s.id = %s AND m.user_id = %s
+                LIMIT 1
+                """,
+                (scan_id, user_id),
+            ).fetchone()
+        if not row:
+            return None
+        return dict(row)

--- a/utils/session_manager_postgres.py
+++ b/utils/session_manager_postgres.py
@@ -1,0 +1,308 @@
+import json
+import threading
+import time
+import uuid
+import logging
+from typing import Any, Dict, List, Optional
+
+
+class PostgresSessionManager:
+    """Postgres-backed session + scan state storage (Supabase-compatible)."""
+
+    TERMINAL_STATUSES = {"completed", "error", "cancelled"}
+
+    def __init__(self, db_url: str):
+        self.db_url = db_url
+        self.lock = threading.Lock()
+        self.logger = logging.getLogger("web_ui")
+        self._init_schema()
+
+    def _connect(self):
+        try:
+            import psycopg  # type: ignore
+            from psycopg.rows import dict_row  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError(
+                "PostgresSessionManager requires psycopg. Install with: pip install 'psycopg[binary]'"
+            ) from exc
+        return psycopg.connect(self.db_url, row_factory=dict_row)
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id TEXT PRIMARY KEY,
+                    created_at DOUBLE PRECISION NOT NULL,
+                    last_activity DOUBLE PRECISION NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS scans (
+                    scan_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+                    url TEXT NOT NULL,
+                    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    started_at DOUBLE PRECISION NOT NULL,
+                    status TEXT NOT NULL,
+                    progress INTEGER NOT NULL DEFAULT 0,
+                    report_dir TEXT,
+                    vulnerabilities JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    action_plan JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    current_task TEXT,
+                    completed_at DOUBLE PRECISION
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_scans_session_started ON scans(session_id, started_at DESC)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_scans_session_completed ON scans(session_id, completed_at DESC)"
+            )
+            conn.commit()
+
+    def _ensure_session_locked(self, conn, session_id: str) -> None:
+        now = time.time()
+        conn.execute(
+            """
+            INSERT INTO sessions(session_id, created_at, last_activity)
+            VALUES (%s, %s, %s)
+            ON CONFLICT (session_id) DO NOTHING
+            """,
+            (session_id, now, now),
+        )
+
+    def _coerce_json(self, value: Any, default: Any) -> Any:
+        if value is None:
+            return default
+        if isinstance(value, (dict, list)):
+            return value
+        if isinstance(value, (bytes, bytearray)):
+            try:
+                value = value.decode("utf-8", errors="ignore")
+            except Exception:
+                return default
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except Exception:
+                return default
+        return default
+
+    def create_session(self) -> str:
+        session_id = str(uuid.uuid4())
+        now = time.time()
+        with self.lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT INTO sessions(session_id, created_at, last_activity)
+                    VALUES (%s, %s, %s)
+                    """,
+                    (session_id, now, now),
+                )
+                conn.commit()
+        return session_id
+
+    def check_session(self, session_id: str) -> bool:
+        now = time.time()
+        with self.lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT 1 FROM sessions WHERE session_id = %s",
+                    (session_id,),
+                ).fetchone()
+                if not row:
+                    conn.commit()
+                    return False
+                conn.execute(
+                    "UPDATE sessions SET last_activity = %s WHERE session_id = %s",
+                    (now, session_id),
+                )
+                conn.commit()
+                return True
+
+    def get_all_sessions(self) -> List[str]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT session_id FROM sessions").fetchall()
+        return [str(r["session_id"]) for r in rows]
+
+    def start_scan(self, session_id: str, url: str, config: Dict[str, Any]) -> str:
+        scan_id = str(uuid.uuid4())
+        now = time.time()
+        with self.lock:
+            with self._connect() as conn:
+                self._ensure_session_locked(conn, session_id)
+                conn.execute(
+                    "UPDATE sessions SET last_activity = %s WHERE session_id = %s",
+                    (now, session_id),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO scans(
+                        scan_id, session_id, url, config, started_at, status, progress, report_dir,
+                        vulnerabilities, action_plan, current_task, completed_at
+                    )
+                    VALUES (
+                        %s, %s, %s, %s::jsonb, %s, %s, %s, %s,
+                        %s::jsonb, %s::jsonb, %s, NULL
+                    )
+                    """,
+                    (
+                        scan_id,
+                        session_id,
+                        url,
+                        json.dumps(config or {}),
+                        now,
+                        "initializing",
+                        0,
+                        None,
+                        json.dumps([]),
+                        json.dumps([]),
+                        None,
+                    ),
+                )
+                conn.commit()
+        return scan_id
+
+    def _scan_row_to_payload(self, scan_id: str, row: Dict[str, Any]) -> Dict[str, Any]:
+        payload = dict(row)
+        payload["id"] = scan_id
+        # Normalize JSON fields to python objects.
+        payload["config"] = self._coerce_json(payload.get("config"), {})
+        payload["vulnerabilities"] = self._coerce_json(payload.get("vulnerabilities"), [])
+        payload["action_plan"] = self._coerce_json(payload.get("action_plan"), [])
+        # Match legacy keys.
+        if "started_at" in payload and "started" not in payload:
+            payload["started"] = payload.get("started_at")
+        if "completed_at" in payload and payload.get("completed_at") and "completed" not in payload:
+            payload["completed"] = payload.get("completed_at")
+        return payload
+
+    def get_active_scan(
+        self, session_id: str, scan_id: str
+    ) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT url, config, started_at, status, progress, report_dir, vulnerabilities, action_plan, current_task, completed_at
+                FROM scans
+                WHERE session_id = %s AND scan_id = %s
+                """,
+                (session_id, scan_id),
+            ).fetchone()
+        if not row:
+            return None
+        if row.get("status") in self.TERMINAL_STATUSES or row.get("completed_at"):
+            return None
+        return self._scan_row_to_payload(scan_id, row)
+
+    def get_active_scans(self, session_id: str) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT scan_id, url, config, started_at, status, progress, report_dir, vulnerabilities, action_plan, current_task, completed_at
+                FROM scans
+                WHERE session_id = %s AND (completed_at IS NULL) AND status NOT IN ('completed','error','cancelled')
+                ORDER BY started_at DESC
+                """,
+                (session_id,),
+            ).fetchall()
+        scans = []
+        for row in rows:
+            scan_id = row.get("scan_id")
+            if not scan_id:
+                continue
+            scans.append(self._scan_row_to_payload(str(scan_id), row))
+        return scans
+
+    def update_scan_status(
+        self,
+        session_id: str,
+        scan_id: str,
+        status: str,
+        progress: int = None,
+        report_dir: str = None,
+        vulnerabilities: List[Dict[str, Any]] = None,
+        action_plan: List[str] = None,
+        current_task: str = None,
+    ) -> None:
+        now = time.time()
+        updates = {}
+        if status:
+            updates["status"] = status
+        if progress is not None:
+            updates["progress"] = int(progress)
+        if report_dir is not None:
+            updates["report_dir"] = report_dir
+        if vulnerabilities is not None:
+            updates["vulnerabilities"] = json.dumps(vulnerabilities)
+        if action_plan is not None:
+            updates["action_plan"] = json.dumps(action_plan)
+        if current_task is not None:
+            updates["current_task"] = current_task
+
+        if not updates:
+            return
+
+        # Terminal transitions set completed_at.
+        if status in self.TERMINAL_STATUSES:
+            updates.setdefault("completed_at", now)
+
+        # Build dynamic SQL safely.
+        set_clauses = []
+        params: List[Any] = []
+        for key, value in updates.items():
+            if key in {"vulnerabilities", "action_plan"}:
+                set_clauses.append(f"{key} = %s::jsonb")
+                params.append(value)
+            else:
+                set_clauses.append(f"{key} = %s")
+                params.append(value)
+        params.extend([session_id, scan_id])
+
+        with self.lock:
+            with self._connect() as conn:
+                self._ensure_session_locked(conn, session_id)
+                conn.execute(
+                    "UPDATE sessions SET last_activity = %s WHERE session_id = %s",
+                    (now, session_id),
+                )
+                conn.execute(
+                    f"UPDATE scans SET {', '.join(set_clauses)} WHERE session_id = %s AND scan_id = %s",
+                    params,
+                )
+                conn.commit()
+
+    def get_completed_scans(self, session_id: str) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT scan_id, url, config, started_at, status, progress, report_dir, vulnerabilities, action_plan, current_task, completed_at
+                FROM scans
+                WHERE session_id = %s AND (completed_at IS NOT NULL OR status IN ('completed','error','cancelled'))
+                ORDER BY completed_at DESC NULLS LAST, started_at DESC
+                """,
+                (session_id,),
+            ).fetchall()
+        scans = []
+        for row in rows:
+            scan_id = row.get("scan_id")
+            if not scan_id:
+                continue
+            scans.append(self._scan_row_to_payload(str(scan_id), row))
+        return scans
+
+    def cleanup_old_sessions(self, max_age_seconds: int = 3600) -> None:
+        cutoff = time.time() - float(max_age_seconds)
+        with self.lock:
+            with self._connect() as conn:
+                conn.execute(
+                    "DELETE FROM sessions WHERE last_activity < %s",
+                    (cutoff,),
+                )
+                conn.commit()
+

--- a/utils/supabase_auth.py
+++ b/utils/supabase_auth.py
@@ -1,0 +1,97 @@
+import logging
+import os
+from typing import Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class SupabaseAuthError(Exception):
+    pass
+
+
+def supabase_auth_enabled() -> bool:
+    """Enable Supabase auth integration when a JWT secret is configured."""
+    return bool(os.environ.get("SUPABASE_JWT_SECRET"))
+
+
+def extract_bearer_token(auth_header: Optional[str]) -> Optional[str]:
+    if not auth_header:
+        return None
+    value = auth_header.strip()
+    if not value:
+        return None
+    if " " not in value:
+        return None
+    scheme, token = value.split(" ", 1)
+    if scheme.strip().lower() != "bearer":
+        return None
+    token = token.strip()
+    return token or None
+
+
+def _expected_issuer() -> Optional[str]:
+    explicit = os.environ.get("SUPABASE_JWT_ISS")
+    if explicit:
+        return explicit
+    supabase_url = os.environ.get("SUPABASE_URL")
+    if not supabase_url:
+        return None
+    return supabase_url.rstrip("/") + "/auth/v1"
+
+
+def verify_supabase_jwt(token: str) -> Dict[str, Any]:
+    secret = os.environ.get("SUPABASE_JWT_SECRET")
+    if not secret:
+        raise SupabaseAuthError("SUPABASE_JWT_SECRET is not set")
+
+    alg = os.environ.get("SUPABASE_JWT_ALG", "HS256").strip() or "HS256"
+    aud = os.environ.get("SUPABASE_JWT_AUD")
+
+    try:
+        import jwt  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise SupabaseAuthError(
+            "Supabase JWT verification requires PyJWT. Install with: pip install PyJWT"
+        ) from exc
+
+    options = {"verify_aud": bool(aud)}
+    kwargs = {}
+    if aud:
+        kwargs["audience"] = aud
+
+    try:
+        payload = jwt.decode(
+            token,
+            secret,
+            algorithms=[alg],
+            options=options,
+            **kwargs,
+        )
+    except Exception as exc:
+        raise SupabaseAuthError("Invalid Supabase access token") from exc
+
+    expected_iss = _expected_issuer()
+    if expected_iss and payload.get("iss") != expected_iss:
+        raise SupabaseAuthError("Invalid token issuer")
+
+    return payload
+
+
+def maybe_get_supabase_user(auth_header: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not supabase_auth_enabled():
+        return None
+    token = extract_bearer_token(auth_header)
+    if not token:
+        return None
+    try:
+        payload = verify_supabase_jwt(token)
+    except SupabaseAuthError as exc:
+        logger.warning("Supabase auth token rejected: %s", exc)
+        return None
+
+    if not payload.get("sub"):
+        logger.warning("Supabase auth token missing 'sub' claim")
+        return None
+    return payload
+

--- a/web_api/__init__.py
+++ b/web_api/__init__.py
@@ -140,6 +140,12 @@ def create_app():
             else:
                 g._set_account_cookie = False
         g.account_id = account_id
+        # Ensure entitlement rows exist for both SQLite and Postgres stores before
+        # checkout completion paths attempt credit/pro updates.
+        try:
+            billing_store.ensure_account(account_id)
+        except Exception as exc:
+            logger.warning(f"Failed to ensure billing account {account_id}: {exc}")
 
     @app.after_request
     def persist_account_identity(response):

--- a/web_api/__init__.py
+++ b/web_api/__init__.py
@@ -22,10 +22,20 @@ from utils.report_manager import ReportManager
 from utils.session_manager import SessionManager
 from utils.scan_controller import ScanController
 from utils.billing_store import BillingStore
+from utils.supabase_auth import maybe_get_supabase_user
 from utils.entitlements import is_hosted_mode
 
 from web_api.middleware.error_handler import register_error_handlers
-from web_api.routes import session, scan, activity, report, status, static, billing
+from web_api.routes import (
+    session,
+    scan,
+    activity,
+    report,
+    status,
+    static,
+    billing,
+    v1_scans,
+)
 
 
 def create_app():
@@ -68,9 +78,29 @@ def create_app():
     register_error_handlers(app)
 
     # Initialize utilities
-    activity_tracker = ActivityTracker()
-    report_manager = ReportManager(app.config["UPLOAD_FOLDER"])
-    session_manager = SessionManager()
+    app_db_url = (
+        os.environ.get("VPT_APP_DB_URL")
+        or os.environ.get("SUPABASE_DATABASE_URL")
+        or os.environ.get("VPT_BILLING_DB_URL")
+    )
+    if app_db_url and app_db_url.startswith(("postgres://", "postgresql://")):
+        from utils.activity_tracker_postgres import PostgresActivityTracker
+        from utils.report_manager_postgres import PostgresReportManager
+        from utils.saas_store import PostgresSaaSStore
+        from utils.session_manager_postgres import PostgresSessionManager
+
+        activity_tracker = PostgresActivityTracker(app_db_url)
+        report_manager = PostgresReportManager(app_db_url, app.config["UPLOAD_FOLDER"])
+        session_manager = PostgresSessionManager(app_db_url)
+        saas_store = PostgresSaaSStore(app_db_url)
+    else:
+        from utils.saas_store import InMemorySaaSStore
+
+        activity_tracker = ActivityTracker()
+        report_manager = ReportManager(app.config["UPLOAD_FOLDER"])
+        session_manager = SessionManager()
+        saas_store = InMemorySaaSStore()
+
     scan_controller = ScanController(session_manager, report_manager)
     if is_vercel:
         default_db_path = "/tmp/vpt.db"
@@ -81,18 +111,35 @@ def create_app():
             "vpt.db",
         )
     db_path = os.environ.get("VPT_BILLING_DB_PATH", default_db_path)
-    billing_store = BillingStore(db_path=db_path)
+    # Prefer explicit billing DB configuration to avoid surprising behavior when
+    # developers have unrelated DATABASE_URL env vars set.
+    billing_db_url = (
+        os.environ.get("VPT_BILLING_DB_URL")
+        or os.environ.get("VPT_APP_DB_URL")
+        or os.environ.get("SUPABASE_DATABASE_URL")
+    )
+    if billing_db_url and billing_db_url.startswith(("postgres://", "postgresql://")):
+        from utils.billing_store_postgres import PostgresBillingStore
+
+        billing_store = PostgresBillingStore(db_url=billing_db_url)
+    else:
+        billing_store = BillingStore(db_path=db_path)
 
     @app.before_request
     def attach_account_identity():
-        account_id = request.cookies.get("vpt_account_id")
-        if not account_id:
-            account_id = str(uuid.uuid4())
-            g._set_account_cookie = True
-        else:
+        supabase_user = maybe_get_supabase_user(request.headers.get("Authorization"))
+        if supabase_user:
+            account_id = str(supabase_user.get("sub"))
+            g.supabase_user = supabase_user
             g._set_account_cookie = False
+        else:
+            account_id = request.cookies.get("vpt_account_id")
+            if not account_id:
+                account_id = str(uuid.uuid4())
+                g._set_account_cookie = True
+            else:
+                g._set_account_cookie = False
         g.account_id = account_id
-        billing_store.ensure_account(account_id)
 
     @app.after_request
     def persist_account_identity(response):
@@ -117,6 +164,15 @@ def create_app():
     )
     activity.register_routes(app, session_manager, activity_tracker)
     report.register_routes(app, session_manager, report_manager)
+    v1_scans.register_routes(
+        app,
+        saas_store,
+        session_manager,
+        scan_controller,
+        activity_tracker,
+        report_manager,
+        billing_store=billing_store,
+    )
     status.register_routes(
         app, session_manager, activity_tracker, billing_store=billing_store
     )

--- a/web_api/routes/v1_scans.py
+++ b/web_api/routes/v1_scans.py
@@ -1,0 +1,307 @@
+"""Versioned SaaS scan endpoints with authenticated org ownership checks."""
+
+import logging
+from functools import wraps
+
+from flask import Blueprint, g, jsonify, request
+
+from web_api.helpers.request_parser import parse_request, get_json_param, normalize_url
+from web_api.helpers.response_formatter import success_response, error_response
+from web_api.middleware.error_handler import handle_errors
+from utils.entitlements import (
+    check_scan_rate_limits,
+    extract_client_ip,
+    is_hosted_mode,
+    is_valid_target_for_hosted,
+    parse_scan_mode,
+    payment_required_payload,
+)
+
+
+logger = logging.getLogger("web_api")
+
+
+def _coerce_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def register_routes(
+    app,
+    saas_store,
+    session_manager,
+    scan_controller,
+    activity_tracker,
+    report_manager,
+    billing_store=None,
+):
+    """Register authenticated v1 scan endpoints."""
+
+    bp = Blueprint("v1_scans", __name__, url_prefix="/api/v1/scans")
+
+    def _require_auth(f):
+        @wraps(f)
+        def wrapped(*args, **kwargs):
+            supabase_user = getattr(g, "supabase_user", None)
+            if not supabase_user or not supabase_user.get("sub"):
+                return error_response("Authentication required", 401)
+            return f(*args, **kwargs)
+
+        return wrapped
+
+    def _make_checkout_url(scan_mode: str) -> str:
+        return f"{request.host_url.rstrip('/')}/billing/checkout?scan_mode={scan_mode}"
+
+    def _enforce_hosted_policy(data, url: str, scan_mode: str):
+        if not is_hosted_mode() or billing_store is None:
+            return None
+
+        account_id = getattr(g, "account_id", None)
+        if not account_id:
+            return error_response("Missing account identity", 400)
+
+        authorization_confirmed = _coerce_bool(data.get("authorization_confirmed"))
+        if not authorization_confirmed:
+            return error_response(
+                "Authorization confirmation is required for hosted scans", 400
+            )
+
+        target_ok, target_reason = is_valid_target_for_hosted(url)
+        if not target_ok:
+            return error_response(target_reason or "Target is blocked in hosted mode", 400)
+
+        ip_address = extract_client_ip(
+            request.remote_addr,
+            request.headers.get("X-Forwarded-For"),
+        )
+        rate_ok, rate_reason = check_scan_rate_limits(
+            billing_store, account_id, ip_address
+        )
+        if not rate_ok:
+            return error_response(rate_reason or "Rate limit exceeded", 429)
+
+        ent_check = billing_store.try_consume_entitlement_for_scan(account_id, scan_mode)
+        if not ent_check["allowed"]:
+            payload = payment_required_payload(
+                ent_check["entitlements"], _make_checkout_url(scan_mode)
+            )
+            return jsonify(payload), 402
+
+        g.pending_entitlement_consume = ent_check["consume"]
+        g.pending_usage_event_ip = ip_address
+        g.entitlements = ent_check["entitlements"]
+        return None
+
+    def _finalize_entitlement_consumption():
+        if not is_hosted_mode() or billing_store is None:
+            return
+
+        account_id = getattr(g, "account_id", None)
+        if not account_id:
+            return
+
+        usage_ip = getattr(g, "pending_usage_event_ip", None)
+        if usage_ip:
+            try:
+                billing_store.record_usage_event(account_id, usage_ip, "scan_start")
+                g.pending_usage_event_ip = None
+            except Exception:
+                logger.exception(
+                    "Failed to record scan usage event for account %s", account_id
+                )
+        g.pending_entitlement_consume = None
+
+    def _rollback_entitlement_consumption():
+        if not is_hosted_mode() or billing_store is None:
+            return
+
+        consume_kind = getattr(g, "pending_entitlement_consume", None)
+        account_id = getattr(g, "account_id", None)
+        if not consume_kind or not account_id:
+            return
+
+        try:
+            billing_store.refund_consumption(account_id, consume_kind)
+            g.entitlements = billing_store.get_entitlements(account_id)
+            g.pending_entitlement_consume = None
+        except Exception:
+            logger.exception(
+                "Failed to refund entitlement after v1 scan start failure for account %s",
+                account_id,
+            )
+
+    def _resolve_scan_status(session_id: str, legacy_scan_id: str):
+        scan = session_manager.get_active_scan(session_id, legacy_scan_id)
+        if scan:
+            return {
+                "status": scan.get("status", "running"),
+                "progress": scan.get("progress", 0),
+                "current_task": scan.get("current_task", scan.get("status", "running")),
+                "is_running": True,
+                "url": scan.get("url", ""),
+                "report_available": False,
+                "report_dir": None,
+                "vulnerabilities": scan.get("vulnerabilities", []),
+                "session_id": session_id,
+                "legacy_scan_id": legacy_scan_id,
+                "agent_logs": activity_tracker.get_activities(session_id),
+            }
+
+        completed_scans = session_manager.get_completed_scans(session_id)
+        for completed in completed_scans:
+            if completed.get("id") != legacy_scan_id:
+                continue
+            report_dir = completed.get("report_dir")
+            return {
+                "status": completed.get("status", "completed"),
+                "progress": completed.get("progress", 100),
+                "current_task": completed.get("current_task", completed.get("status", "completed")),
+                "is_running": False,
+                "url": completed.get("url", ""),
+                "report_available": bool(report_dir),
+                "report_dir": report_dir,
+                "vulnerabilities": completed.get("vulnerabilities", []),
+                "session_id": session_id,
+                "legacy_scan_id": legacy_scan_id,
+                "agent_logs": activity_tracker.get_activities(session_id),
+            }
+        return None
+
+    @bp.route("", methods=["POST"])
+    @handle_errors
+    @_require_auth
+    def create_scan():
+        data = parse_request()
+        url = normalize_url(data.get("url"))
+        if not url:
+            return error_response("Missing target URL", 400)
+
+        config = get_json_param(data, "config", default={}) or {}
+        scan_mode = parse_scan_mode(data.get("scan_mode") or config.get("scan_mode"))
+        config["scan_mode"] = scan_mode
+
+        policy_response = _enforce_hosted_policy(data, url, scan_mode)
+        if policy_response is not None:
+            return policy_response
+
+        supabase_user = g.supabase_user
+        user_id = str(supabase_user["sub"])
+        user_ctx = saas_store.ensure_user_org(user_id, supabase_user.get("email"))
+
+        # Versioned API scan identifier maps to existing session/scan runtime state.
+        session_id = session_manager.create_session()
+
+        def activity_adapter(session_id, activity):
+            activity_type = activity.get("type", "general")
+            description = activity.get("description", "Activity")
+            details = activity.get("details", {})
+            agent_name = activity.get("agent", None)
+            return activity_tracker.add_activity(
+                session_id, activity_type, description, details, agent_name
+            )
+
+        try:
+            legacy_scan_id = scan_controller.start_scan(
+                session_id, url, config, activity_callback=activity_adapter
+            )
+            v1_scan_id = saas_store.create_scan(
+                org_id=user_ctx["org_id"],
+                created_by_user_id=user_id,
+                target_url=url,
+                mode=scan_mode,
+                session_id=session_id,
+                legacy_scan_id=legacy_scan_id,
+            )
+        except Exception:
+            _rollback_entitlement_consumption()
+            raise
+        _finalize_entitlement_consumption()
+
+        response_data = {
+            "scan": {
+                "id": v1_scan_id,
+                "status": "queued",
+                "target_url": url,
+                "mode": scan_mode,
+                "created_by_user_id": user_id,
+                "org_id": user_ctx["org_id"],
+            }
+        }
+        if getattr(g, "entitlements", None):
+            response_data["entitlements"] = g.entitlements
+        return success_response(data=response_data, status_code=201)
+
+    @bp.route("/<scan_id>", methods=["GET"])
+    @handle_errors
+    @_require_auth
+    def get_scan(scan_id):
+        user_id = str(g.supabase_user["sub"])
+        record = saas_store.get_scan_for_user(scan_id, user_id)
+        if not record:
+            return error_response("Scan not found", 404)
+
+        status_payload = _resolve_scan_status(record["session_id"], record["legacy_scan_id"])
+        if not status_payload:
+            return error_response("Scan not found", 404)
+
+        return success_response(
+            data={
+                "scan": {
+                    "id": scan_id,
+                    "org_id": record["org_id"],
+                    "created_by_user_id": record["created_by_user_id"],
+                    "target_url": record["target_url"],
+                    "mode": record["mode"],
+                    **status_payload,
+                }
+            }
+        )
+
+    @bp.route("/<scan_id>/report", methods=["GET"])
+    @handle_errors
+    @_require_auth
+    def get_scan_report(scan_id):
+        user_id = str(g.supabase_user["sub"])
+        record = saas_store.get_scan_for_user(scan_id, user_id)
+        if not record:
+            return error_response("Scan not found", 404)
+
+        status_payload = _resolve_scan_status(record["session_id"], record["legacy_scan_id"])
+        if not status_payload:
+            return error_response("Scan not found", 404)
+        if status_payload["is_running"]:
+            return success_response(
+                message="Scan is in progress",
+                data={
+                    "scan_id": scan_id,
+                    "status": "in_progress",
+                    "progress": status_payload["progress"],
+                },
+                status_code=202,
+            )
+        if not status_payload["report_dir"]:
+            return success_response(
+                message="Report is being generated",
+                data={
+                    "scan_id": scan_id,
+                    "status": "generating",
+                    "progress": status_payload["progress"],
+                },
+                status_code=202,
+            )
+
+        report = report_manager.get_report(status_payload["report_dir"])
+        if isinstance(report, dict) and report.get("error") == "Report not found":
+            return error_response("Report not found", 404)
+
+        return success_response(
+            data={
+                "scan_id": scan_id,
+                "report": report,
+            }
+        )
+
+    app.register_blueprint(bp)

--- a/web_ui.py
+++ b/web_ui.py
@@ -152,6 +152,12 @@ def attach_account_identity():
         else:
             request._vpt_new_account_cookie = False
     request._vpt_account_id = account_id
+    # Keep billing identity materialized so SQLite update-only paths do not
+    # silently drop credits/pro upgrades when no entitlement row exists yet.
+    try:
+        billing_store.ensure_account(account_id)
+    except Exception as exc:
+        logger.warning(f"Failed to ensure billing account {account_id}: {exc}")
 
 
 @app.after_request


### PR DESCRIPTION
## Summary
- add Supabase JWT auth plumbing and Postgres-backed stores for sessions, activity, reports, billing, and SaaS ownership
- add authenticated `/api/v1/scans` endpoints with org ownership checks
- add endpoint inventory docs + route snapshot contract tests + snapshot update/list scripts
- add/expand API/frontend/legacy/live E2E coverage for hosted/unhosted behavior, billing/rate-limit paths, and report fetch-by-id
- make real scan subprocess invocation portable via `sys.executable` and add a unit test for it

## Testing
- `python3 -m pytest tests/unit -q`
- `python3 -m pytest tests/integration -q`
- `python3 -m pytest tests/contract -q`
- `python3 -m pytest tests/e2e/api -q`
- `python3 -m pytest tests/e2e/frontend -q`
- `python3 -m pytest tests/e2e/legacy -q`
- `VPT_LIVE_E2E=1 python3 -m pytest tests/e2e/live/test_live_scan_e2e.py -q`

## Notes
- Vercel preview smoke tests are still environment-gated (`VPT_BASE_URL`/`VERCEL_PREVIEW_URL`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication/identity and swaps core persistence (sessions, billing, reports) to optional Postgres paths, which can impact authorization boundaries and data consistency if misconfigured.
> 
> **Overview**
> Adds **optional Supabase integration**: when `SUPABASE_JWT_SECRET` is configured, requests can authenticate via `Authorization: Bearer ...`, deriving `account_id` from the JWT `sub` and enabling a new authenticated, org-scoped `/api/v1/scans` API.
> 
> Introduces **Postgres-backed stores** (via `psycopg`) for billing/entitlements, sessions/scan state, activity logs, reports (including DB fallback for `/reports/<...>` downloads), and SaaS ownership mapping; `web_api` and `web_ui` now select Postgres vs SQLite/filesystem based on `VPT_*_DB_URL`/`SUPABASE_DATABASE_URL`.
> 
> Improves test/dev stability by adding an offline deterministic `mock` LLM provider, making scan subprocess execution use `sys.executable`, documenting route inventories, adding route snapshot contract tests + regen scripts, and expanding API/frontend/live E2E tests for hosted/unhosted policy, paywall, rate limiting, and report fetch-by-id flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98f2ac13c61e2148815ca46359dd87f311211068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->