### PR TITLE
Update runnable models to GPT-5.2/Codex + Claude Opus 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,19 @@ cp .env.example .env
 python main.py --url https://example.com
 
 # Domain-level scan with OpenAI
-python main.py --url https://example.com --scope domain --provider openai --model gpt-4o
+python main.py --url https://example.com --scope domain --provider openai --model gpt-5.2
 
-# OpenAI Codex model
-python main.py --url https://example.com --provider openai --model gpt-5.3-codex
+# OpenAI GPT-5.2 Codex model
+python main.py --url https://example.com --provider openai --model gpt-5.2-codex
+
+# OpenAI GPT-5.2 Thinking model
+python main.py --url https://example.com --provider openai --model gpt-5.2-pro
 
 # Subdomain scan with Anthropic
-python main.py --url https://example.com --scope subdomain --provider anthropic --model claude-3-7-sonnet-20250219
+python main.py --url https://example.com --scope subdomain --provider anthropic --model claude-opus-4-6
 
 # Anthropic Opus model
-python main.py --url https://example.com --provider anthropic --model claude-opus-4.6
+python main.py --url https://example.com --provider anthropic --model claude-opus-4-6-20260120
 
 # Local scan with Ollama
 python main.py --url https://example.com --provider ollama --model llama3
@@ -108,15 +111,17 @@ python main.py --url https://example.com --provider ollama --model mixtral --oll
 Use any provider model ID accepted by your account/runtime. Common options:
 
 - OpenAI:
-  - `gpt-4o`
-  - `gpt-4.1`
-  - `gpt-5`
-  - `gpt-5.3-codex`
-  - `o3`
+  - `gpt-5.2`
+  - `gpt-5.2-pro` (thinking)
+  - `gpt-5.2-codex`
+  - `gpt-5.2-mini`
+  - `gpt-5.2-nano`
+  - `gpt-4o` (legacy)
 - Anthropic:
-  - `claude-3-7-sonnet-20250219`
-  - `claude-opus-4.6`
-  - `claude-3-5-haiku-20241022`
+  - `claude-opus-4-6`
+  - `claude-opus-4-6-20260120`
+  - `claude-sonnet-4-6`
+  - `claude-haiku-4-5`
 - Ollama (example local tags):
   - `llama3`
   - `mixtral`
@@ -129,7 +134,7 @@ Use any provider model ID accepted by your account/runtime. Common options:
 | Option | Description |
 | --- | --- |
 | `--url` | Target URL to test (required) |
-| `--model` | LLM model identifier (default `gpt-4o`) |
+| `--model` | LLM model identifier (default `gpt-5.2`) |
 | `--provider` | LLM provider: `openai`, `anthropic`, `ollama` |
 | `--scope` | Scan scope: `url`, `domain`, `subdomain` |
 | `--output` | Output directory root (default `reports`) |

--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ from utils.config import load_config
 # Load environment variables from .env file
 load_dotenv()
 
+DEFAULT_OPENAI_MODEL = "gpt-5.2"
+
 
 def parse_arguments():
     available_providers = ["openai", "anthropic", "ollama"]
@@ -27,8 +29,8 @@ def parse_arguments():
     parser.add_argument(
         "--model",
         type=str,
-        default="gpt-4o",
-        help="LLM model to use (e.g., gpt-4o, claude-3-5-sonnet, ollama/llama3, gemini-1.5-pro)",
+        default=DEFAULT_OPENAI_MODEL,
+        help="LLM model to use (e.g., gpt-5.2, gpt-5.2-codex, claude-opus-4-6, ollama/llama3, gemini-2.0-flash)",
     )
     parser.add_argument(
         "--provider",
@@ -87,7 +89,7 @@ def main():
 
         # If no specific model is provided, use the default from config
         if (
-            args.model == "gpt-4o"
+            args.model == DEFAULT_OPENAI_MODEL
         ):  # This is the default model, so user didn't specify one
             default_ollama_model = (
                 config.get("llm", {}).get("ollama", {}).get("default_model", "llama3")

--- a/templates/index.html
+++ b/templates/index.html
@@ -282,16 +282,19 @@
                                         <label for="model" class="form-label">LLM Model</label>
                                         <select class="form-select" id="model" name="model">
                                             <optgroup label="OpenAI Models" id="openai-models">
-                                                <option value="gpt-4o" selected>GPT-4o</option>
-                                                <option value="gpt-4-turbo">GPT-4 Turbo</option>
-                                                <option value="gpt-4">GPT-4</option>
-                                                <option value="gpt-3.5-turbo">GPT-3.5 Turbo</option>
+                                                <option value="gpt-5.2" selected>GPT-5.2</option>
+                                                <option value="gpt-5.2-pro">GPT-5.2 Thinking (Pro)</option>
+                                                <option value="gpt-5.2-codex">GPT-5.2 Codex</option>
+                                                <option value="gpt-5.2-mini">GPT-5.2 Mini</option>
+                                                <option value="gpt-5.2-nano">GPT-5.2 Nano</option>
+                                                <option value="gpt-4o">GPT-4o (Legacy)</option>
                                             </optgroup>
                                             <optgroup label="Anthropic Models" id="anthropic-models" style="display:none">
-                                                <option value="claude-3-5-sonnet">Claude 3.5 Sonnet</option>
-                                                <option value="claude-3-opus">Claude 3 Opus</option>
-                                                <option value="claude-3-sonnet">Claude 3 Sonnet</option>
-                                                <option value="claude-3-haiku">Claude 3 Haiku</option>
+                                                <option value="claude-opus-4-6">Claude Opus 4.6</option>
+                                                <option value="claude-opus-4-6-20260120">Claude Opus 4.6 (Snapshot)</option>
+                                                <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+                                                <option value="claude-sonnet-4-6-20260120">Claude Sonnet 4.6 (Snapshot)</option>
+                                                <option value="claude-haiku-4-5">Claude Haiku 4.5</option>
                                             </optgroup>
                                             <optgroup label="Ollama Models" id="ollama-models" style="display:none">
                                                 <option value="llama3">Llama 3</option>


### PR DESCRIPTION
## Summary
- update CLI and web model catalogs to include GPT-5.2 family (`gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `gpt-5.2-mini`, `gpt-5.2-nano`) plus Claude 4.6 variants
- set default OpenAI model to `gpt-5.2` and Anthropic fallback model to `claude-opus-4-6`
- add OpenAI Responses API routing/fallback for response-only Codex/Thinking model IDs so selected models actually run
- refresh README model examples and model option docs
- add unit coverage for codex model initialization and Responses API tool-call behavior

## Validation
- `python3 -m pytest -q tests/unit/test_llm.py` (17 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes LLM request routing and response parsing for certain OpenAI models, which can affect tool-calling behavior and output handling across scans. Surface area is limited to model selection/docs and `core/llm.py` provider logic with added unit coverage.
> 
> **Overview**
> Switches the default OpenAI model from `gpt-4o` to `gpt-5.2` (CLI, README docs, and OpenAI unknown-model fallback), and updates the README + web UI model catalogs to GPT‑5.2 variants and Claude Opus/Sonnet/Haiku 4.x IDs.
> 
> Adds OpenAI **Responses API** support in `LLMProvider` for response-only models (Codex/Thinking): detects these model IDs, converts chat messages + tool calls into Responses `input`, flattens tool specs, parses Responses outputs back into the existing `choices[].message` shape, and falls back to Responses when Chat Completions returns an unsupported-model error. Unit tests are updated/added to cover the new defaults, `codex-latest` support, and the Responses tool-call path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81c5c2ffca19dbac78ff72063507e9a21200697c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->